### PR TITLE
Add `dap.up` and `dap.down`

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -200,6 +200,12 @@ step_into()                                                    *dap.step_into()*
 step_out()                                                      *dap.step_out()*
         Requests the debugee to step out of a function or method if possible.
 
+up()                                                                  *dap.up()*
+        Go up in current stacktrace without stepping.
+
+down()                                                              *dap.down()*
+        Go down in current stacktrace without stepping.
+
 
 repl.open()                                                    *dap.repl.open()*
         Open a REPL / Debug-console.
@@ -214,6 +220,8 @@ repl.open()                                                    *dap.repl.open()*
           .n or .next         Same as |dap.step_over|
           .into               Same as |dap.step_into|
           .out                Same as |dap.step_out|
+          .up                 Same as |dap.up|
+          .down               Same as |dap.down|
           .scopes             Prints the variables in the current scopes
           .threads            Prints all threads
           .frames             Print the stack frames
@@ -229,5 +237,7 @@ repl.open()                                                    *dap.repl.open()*
             threads = {'.threads'},
             frames = {'.frames'},
             exit = {'exit', '.exit'},
+            up = {'.up'},
+            down = {'.down'},
           }
 }


### PR DESCRIPTION
This implements the basic functionality of up/down, i.e. jump to a different frame in stack.

What is not (yet) implemented is to execute stepping commands relative to current frame. One possibility would be to issue multiple 'stepOut' request until the debugger reaches the current frame before performing the actual stepping. Since this is a bit a hack, I omitted it from this PR.

I noticed, that with the current dictionary approach the users must update their config when new repl commands are added. So either the documentation should be changed to recommend something like this 
```lua
dap.repl.commands.continue = {'continue', '.c'}
dap.repl.commands.next_ = {'next '}
```
or we reverse the look-up direction of this dict (see https://github.com/mfussenegger/nvim-dap/pull/8#issuecomment-626174313) or we to a `vim.tbl_merge` with given defaults.