### PR TITLE
[WIP]: Virtual text

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -339,7 +339,7 @@ function Session:event_stopped(stopped)
       jump_to_frame(current_frame, stopped.preserveFocusHint)
 
       if vim.g.dap_virtual_text == 'all frames' then
-        virtual_text.clear_virtual_text()
+        virtual_text.clear_virtual_text(current_frame)
         local requested_functions = {}
         for _, f in pairs(frames) do
           -- Ensure to evaluate the same function only once to avoid race conditions
@@ -382,10 +382,10 @@ function Session.event_output(_, body)
 end
 
 function Session:_request_scopes(current_frame)
-  if vim.g.dap_virtual_text ~= 'all frames' then
-    virtual_text.clear_virtual_text()
-  end
   self:request('scopes', { frameId = current_frame.id }, function(_, scopes_resp)
+    if vim.g.dap_virtual_text ~= 'all frames' then
+      virtual_text.clear_virtual_text(current_frame)
+    end
     if not scopes_resp or not scopes_resp.scopes then return end
 
     current_frame.scopes = {}

--- a/lua/dap/virtual_text.lua
+++ b/lua/dap/virtual_text.lua
@@ -1,0 +1,93 @@
+
+M = {}
+
+local hl_namespace
+local api = vim.api
+
+local require_ok, locals = pcall(require, "nvim-treesitter.locals")
+local require_ok, utils = pcall(require, "nvim-treesitter.utils")
+
+if not hl_namespace then
+  hl_namespace = api.nvim_create_namespace("dap.treesitter")
+end
+
+local function is_in_node_range(node, line, col)
+  local start_line, start_col, end_line, end_col = node:range()
+  if line >= start_line and line <= end_line then
+    if line == start_line and line == end_line then
+      return col >= start_col and col < end_col
+    elseif line == start_line then
+      return col >= start_col
+    elseif line == end_line then
+      return col < end_col
+    else
+      return true
+    end
+  else
+    return false
+  end
+end
+
+function M.set_virtual_text(stackframe)
+  if not stackframe then return end
+  if not stackframe.scopes then return end
+  if not require_ok then return end
+
+  local buf = vim.uri_to_bufnr(vim.uri_from_fname(stackframe.source.path))
+
+  local scope_nodes = locals.get_scopes(buf)
+  local definition_nodes = locals.get_definitions(buf)
+  local variables = {}
+
+  for _, s in ipairs(stackframe.scopes) do
+    if s.variables then
+      for _, v in pairs(s.variables) do
+        variables[v.name] = v
+      end
+    end
+  end
+
+  local virtual_text = {}
+  for _, d in pairs(definition_nodes) do
+    if d and d.var then -- is definition and is variable definition?
+      local node = d.var.node
+      local name = utils.get_node_text(node, buf)[1]
+      local var_line, var_col = node:start()
+
+      local evaluated = variables[name]
+      if evaluated then -- evaluated local with same name exists
+
+        -- is this name really the local or is it in another scope?
+        local in_scope = true
+        for _, scope in ipairs(scope_nodes) do
+          if is_in_node_range(scope, var_line, var_col) and not is_in_node_range(scope, stackframe.line - 1, 0) then
+            in_scope = false
+            break
+          end
+        end
+
+        if in_scope then
+          virtual_text[node:start()] = (virtual_text[node:start()] and virtual_text[node:start()]..', ' or '')..name..' = '..evaluated.value
+        end
+      end
+    end
+  end
+
+  for line, content in pairs(virtual_text) do
+    api.nvim_buf_set_virtual_text(buf, hl_namespace, line, {{content, "Comment"}}, {})
+  end
+
+end
+
+function M.clear_virtual_text(stackframe)
+  if stackframe then
+    local buf = vim.uri_to_bufnr(vim.uri_from_fname(stackframe.source.path))
+    api.nvim_buf_clear_namespace(buf, hl_namespace, 0, -1)
+  else
+    for _, buf in ipairs(api.nvim_list_bufs()) do
+      api.nvim_buf_clear_namespace(buf, hl_namespace, 0, -1)
+    end
+  end
+end
+
+return M


### PR DESCRIPTION
Currently this PR is still based on the up-down branch. I will rebase and squash everything if everything is ok with this PR.

Add virtual text annotations with the current values of the locals at the spot of their definition. I use nvim-treesitter to get the definition locations and the scopes of the current stack trace. So without nvim-treesitter and a treesitter parser for the given language installed, this change won't be activated.

The whole functionality is controlled by the variable `vim.g.dap_virtual_text` which can have the values `nil`, `false`, `anything else` and `'all frames'`. Virtual text is deactivated by default.

With `vim.g.dap_virtual_text=true`

![current_frame](https://user-images.githubusercontent.com/7189118/81495691-5d937400-92b2-11ea-8995-17daeda593cc.gif)

With `vim.g.dap_virtual_text='all frames'`

![all_scopes](https://user-images.githubusercontent.com/7189118/81495701-6b48f980-92b2-11ea-8df4-dd476dc825bc.gif)

An additional requirement are scope definitions for the language to be debugged (currently nvim-treesitter has this only for lua and ruby). I can add this later for python. E.g. by placing the following file into `nvim-treesitter/queries/python/locals.scm`:

```scheme
;;; Programm structure
(module) @scope

(class_definition
  body: (block
          (expression_statement
            (assignment
              left: (expression_list
                      (identifier) @definition.associated))))) @scope

; Function with parameters, defines parameters
(function_definition
  name: (identifier)
  parameters: (parameters
                (identifier) @definition.var))

; Function defines function and scope
(function_definition
  name: (identifier) @definition.function) @scope


;;; Loops
(for_statement
  left: (variables
    (identifier) @definition.var)) @scope

(while_statement) @scope


;;; Assignments
(assignment
  left: (expression_list
    (identifier) @definition.var))

; Walrus operator  x := 1
(named_expression
  (identifier) @definition.var)


;;; REFERENCES
(identifier) @reference
``` 
