### PR TITLE
Add Goto command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - [ ] set exception breakpoints
 - [x] step over, step into, step out
 - [ ] step back, reverse continue
-- [ ] Goto
+- [x] Goto
 - [x] restart
 - [x] stop
 - [x] evaluate expressions

--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -207,6 +207,13 @@ down()                                                              *dap.down()*
         Go down in current stacktrace without stepping.
 
 
+goto_({line})                                                      *dap.goto_()*
+        Let the debugger jump to a specific line or line under cursor.
+
+        Parameters: ~
+            {line}  Line number or line under cursor if nil.
+
+
 repl.open()                                                    *dap.repl.open()*
         Open a REPL / Debug-console.
 

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -17,6 +17,7 @@ M.commands = {
   exit = {'exit', '.exit'},
   up = {'.up'},
   down = {'.down'},
+  goto_ = {'.goto'}
 }
 
 function M.print_stackframes()
@@ -105,6 +106,11 @@ function M.execute(text)
   elseif vim.tbl_contains(M.commands.down, text) then
     session:_frame_delta(-1)
     M.print_stackframes()
+  elseif vim.tbl_contains(M.commands.goto_, vim.split(text, ' ')[1]) then
+    local split = vim.split(text, ' ')
+    if split[2] then
+      session:_goto(tonumber(split[2]))
+    end
   elseif vim.tbl_contains(M.commands.scopes, text) then
     local frame = session.current_frame
     if frame then


### PR DESCRIPTION
- Add a `.goto` repl command. E.g. `.goto 10` to jump to line 10. This is supported by debugpy. Debugpy ignores all other arguments.

- Add `dap.goto_({line}`) to jump to line under cursor or a specific line.

In theory, the debug server could offer more than one jump target. I am just taking the first one if any. 

## GotoTargets Request

This request retrieves the possible goto targets for the specified source location.

These targets can be used in the ‘goto’ request.

Clients should only call this request if the capability ‘supportsGotoTargetsRequest’ is true.
```
interface GotoTargetsRequest extends Request {
  command: 'gotoTargets';

  arguments: GotoTargetsArguments;
}
```

Arguments for ‘gotoTargets’ request.

```
interface GotoTargetsArguments {
  /**
   * The source location for which the goto targets are determined.
   */
  source: Source;

  /**
   * The line location for which the goto targets are determined.
   */
  line: number;

  /**
   * An optional column location for which the goto targets are determined.
   */
  column?: number;
}
```

Response to ‘gotoTargets’ request.

```
interface GotoTargetsResponse extends Response {
  body: {
    /**
     * The possible goto targets of the specified location.
     */
    targets: GotoTarget[];
  };
}
```


## GotoRequest

```
interface GotoRequest extends Request {
  command: 'goto';

  arguments: GotoArguments;
}
```

Arguments for ‘goto’ request.
```
interface GotoArguments {
  /**
   * Set the goto target for this thread.
   */
  threadId: number;

  /**
   * The location where the debuggee will continue to run.
   */
  targetId: number;
}
```

Response to ‘goto’ request. This is just an acknowledgement, so no body field is required.

```
interface GotoResponse extends Response {
}
```
