### PR TITLE
Reset arrow after frame switch

### DIFF
--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -98,6 +98,19 @@ function M.on_enter()
     local frame = frames_marks[mark_id]
     if frame then
       session:_frame_set(frame)
+      local new_marks = {}
+      for m, f in pairs(frames_marks) do
+        local mark = api.nvim_buf_get_extmark_by_id(buf, frames_ns, m)
+        local line =  mark[1]
+        if f.id == frame.id then
+          api.nvim_buf_set_lines(buf, line, line + 1, true, {'→ '..f.name})
+        else
+          api.nvim_buf_set_lines(buf, line, line + 1, true, {'  '..f.name})
+        end
+        local new_mark = api.nvim_buf_set_extmark(buf, frames_ns, 0, line, 0, {})
+        new_marks[new_mark] = f
+      end
+      frames_marks = new_marks
     end
   end
 end


### PR DESCRIPTION
~~I guess you renamed: `_set_frame` to `_frame_set`.~~

~~This PR fixes up/down for that change.~~

Resets the `->` after pressing enter on a frame. ~~If it's to much complexity for this mini-feature I'll just drop the corresponding commit.~~