### PR TITLE
Add support for reverse debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ things may break.
 - [ ] set function breakpoints
 - [x] set exception breakpoints
 - [x] step over, step into, step out
-- [ ] step back, reverse continue
+- [x] step back, reverse continue
 - [x] Goto
 - [x] restart
 - [x] stop

--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -314,6 +314,13 @@ step_into()                                                    *dap.step_into()*
 step_out()                                                      *dap.step_out()*
         Requests the debugee to step out of a function or method if possible.
 
+step_back()                                                    *dap.step_back()*
+        Steps one step back. Debug adapter must support reverse debugging.
+
+reverse_continue()                                      *dap.reverse_continue()*
+        Continues execution reverse in time until last breakpoint.
+        Debug adapter must support reverse debugging.
+
 up()                                                                  *dap.up()*
         Go up in current stacktrace without stepping.
 
@@ -354,12 +361,17 @@ repl.open({winopts})                                           *dap.repl.open()*
           .threads            Prints all threads
           .frames             Print the stack frames
           .capabilities       Print the capabilities of the debug adapter
+          .b or .back         Same as |dap.step_back|
+          .rc or
+          .reverse-continue   Same as |dap.reverse_continue|
 
         You can customize the commands by overriding `dap.repl.commands`:
         >
           dap.repl.commands = vim.tbl_extend('force', dap.repl.commands, {
             continue = {'.continue', '.c'},
             next_ = {'.next', '.n'},
+            back = {'.back', '.b'},
+            reverse_continue = {'.reverse-continue', '.rc'},
             into = {'.into'},
             out = {'.out'},
             scopes = {'.scopes'},

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -935,6 +935,10 @@ end
 
 
 function Session:_step(step)
+  if vim.tbl_contains({"stepBack", "reverseContinue"}, step) and not session.capabilities.supportsStepBack then
+    print("Debug Adapter does not support "..step.."!")
+    return
+  end
   if not self.stopped_thread_id then
     print('No stopped thread. Cannot move')
     return
@@ -963,6 +967,16 @@ end
 function M.step_out()
   if not session then return end
   session:_step('stepOut')
+end
+
+function M.reverse_continue()
+  if not session then return end
+  session:_step('reverseContinue')
+end
+
+function M.step_back()
+  if not session then return end
+  session:_step('stepBack')
 end
 
 function M.stop()

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -19,6 +19,8 @@ local frames_marks = {}
 M.commands = {
   continue = {'.continue', '.c'},
   next_ = {'.next', '.n'},
+  step_back = {'.back', '.b'},
+  reverse_continue = {'.reverse-continue', '.rc'},
   into = {'.into'},
   out = {'.out'},
   scopes = {'.scopes'},
@@ -93,6 +95,10 @@ local function execute(text)
   elseif vim.tbl_contains(M.commands.up, text) then
     session:_frame_delta(1)
     M.print_stackframes()
+  elseif vim.tbl_contains(M.commands.step_back, text) then
+    session:_step('stepBack')
+  elseif vim.tbl_contains(M.commands.reverse_continue, text) then
+    session:_step('reverseContinue')
   elseif vim.tbl_contains(M.commands.down, text) then
     session:_frame_delta(-1)
     M.print_stackframes()

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -111,7 +111,7 @@ local function execute(text)
     if frame then
       for _, scope in pairs(frame.scopes) do
         M.append(string.format("%s  (frame: %s)", scope.name, frame.name))
-        for _, variable in pairs(scope.variables) do
+        for _, variable in pairs(scope.variables or {}) do
           M.append(string.rep(' ', 2) .. variable.name .. ': ' .. variable.value)
         end
       end


### PR DESCRIPTION
Reading the DAP docs, I guess `stepBack` and `reverseContinue` just work as the normal stepping commands.

Didn't find the time yet to test with `lldb-vscode`+`rr` or with https://github.com/Microsoft/vscode-mock-debug.