### PR TITLE
Add support for exception breakpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - [x] breakpoints with conditions
 - [x] logpoints
 - [ ] set function breakpoints
-- [ ] set exception breakpoints
+- [x] set exception breakpoints
 - [x] step over, step into, step out
 - [ ] step back, reverse continue
 - [x] Goto

--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -228,6 +228,28 @@ list_breakpoints()                                       *dap.list_breakpoints()
 
         Lists all breakpoints and log points in quickfix window.
 
+set_exception_breakpoints({filters})           *dap.set_exception_breakpoints()*
+
+    Sets breakpoints on exceptions filtered by `filters`. If `filters` is not
+    provided it will prompt the user to choose from the available filters of the
+    debug adapter.
+
+    Parameters: ~
+        {filters}  A list of exception types to stop on (optional).
+                   For most debug adapters you can use `uncaught` and `raised`
+                   to filter the exceptions.
+         
+    >
+        -- Ask user to stop on which kinds of exceptions
+        require'dap'.set_exception_breakpoints()
+        -- don't stop on exceptions
+        require'dap'.set_exception_breakpoints({})
+        -- stop only on uncaughted exceptions
+        require'dap'.set_exception_breakpoints({"uncaughted"})
+        -- stop on all exceptions
+        require'dap'.set_exception_breakpoints({"raised", "uncaught"})
+    <
+
 step_over()                                                    *dap.step_over()*
         Requests the debugee to run again for one step.
 

--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -236,8 +236,11 @@ set_exception_breakpoints({filters})           *dap.set_exception_breakpoints()*
 
     Parameters: ~
         {filters}  A list of exception types to stop on (optional).
-                   For most debug adapters you can use `uncaught` and `raised`
-                   to filter the exceptions.
+                   For most debug adapters you can use `"uncaught"` and
+                   `"raised`" to filter the exceptions.
+                   If set to "default" instead of a table, the
+                   default options as recommended by the debug adapter are
+                   used.
          
     >
         -- Ask user to stop on which kinds of exceptions
@@ -248,6 +251,8 @@ set_exception_breakpoints({filters})           *dap.set_exception_breakpoints()*
         require'dap'.set_exception_breakpoints({"uncaughted"})
         -- stop on all exceptions
         require'dap'.set_exception_breakpoints({"raised", "uncaught"})
+        -- use default settings of debug adapter
+        require'dap'.set_exception_breakpoints("default")
     <
 
 step_over()                                                    *dap.step_over()*

--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -224,32 +224,34 @@ toggle_breakpoint({condition}, {hit_condition}, {log_message})
                             into a log point. Variable interpolation with {foo} is
                             supported within the message.
 
-list_breakpoints()                                       *dap.list_breakpoints()*
+list_breakpoints()                                     *dap.list_breakpoints()*
 
         Lists all breakpoints and log points in quickfix window.
 
-set_exception_breakpoints({filters})           *dap.set_exception_breakpoints()*
+set_exception_breakpoints({filters}, {exceptionOptions})
+                                              *dap.set_exception_breakpoints()*
 
     Sets breakpoints on exceptions filtered by `filters`. If `filters` is not
     provided it will prompt the user to choose from the available filters of the
     debug adapter.
 
     Parameters: ~
-        {filters}  A list of exception types to stop on (optional).
-                   For most debug adapters you can use `"uncaught"` and
-                   `"raised`" to filter the exceptions.
-                   If set to "default" instead of a table, the
-                   default options as recommended by the debug adapter are
-                   used.
+        {filters}          A list of exception types to stop on (optional).
+                           Most debug adapters offer categories like `"uncaught"` and
+                           `"raised"` to filter the exceptions.
+                           If set to "default" instead of a table, the
+                           default options as recommended by the debug adapter are
+                           used.
+        {exceptionOptions} ExceptionOptions[]?
+                           (https://microsoft.github.io/debug-adapter-protocol/specification#Types_ExceptionOptions)
          
     >
         -- Ask user to stop on which kinds of exceptions
         require'dap'.set_exception_breakpoints()
         -- don't stop on exceptions
         require'dap'.set_exception_breakpoints({})
-        -- stop only on uncaughted exceptions
+        -- stop only on certain exceptions (debugpy offers "raised", "uncaught")
         require'dap'.set_exception_breakpoints({"uncaughted"})
-        -- stop on all exceptions
         require'dap'.set_exception_breakpoints({"raised", "uncaught"})
         -- use default settings of debug adapter
         require'dap'.set_exception_breakpoints("default")


### PR DESCRIPTION
```lua
-- Ask user to stop on which kinds of exceptions
require'dap'.set_exception_breakpoints()
-- don't stop on exceptions
require'dap'.set_exception_breakpoints({})
-- stop only on uncaughted exceptions
require'dap'.set_exception_breakpoints({"uncaughted"})
-- stop on all exceptions
require'dap'.set_exception_breakpoints({"raised", "uncaught"})

```

TODO:

 - [x] docs