### PR TITLE
Filter out possible nil values before applying table.concat

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -989,12 +989,12 @@ function M.list_breakpoints(open_quickfix)
       local condition = bp_entry.condition;
       local hitCondition = bp_entry.hitCondition;
       local logMessage = bp_entry.logMessage;
-      local text = table.concat({
+      local text = table.concat(vim.tbl_filter(function(v) return v end, {
                unpack(api.nvim_buf_get_lines(bufnr, bp.lnum - 1, bp.lnum, false), 1),
                non_empty_sequence(logMessage) and "Log message: "..logMessage,
                non_empty_sequence(condition) and "Condition: "..condition,
                non_empty_sequence(hitCondition) and "Hit condition: "..hitCondition,
-             }, ', ')
+             }), ', ')
       table.insert(qf_list, {
         bufnr = bufnr,
         lnum = bp.lnum,


### PR DESCRIPTION
In that branch, this table.concat was in line 905. 

![nil](https://user-images.githubusercontent.com/7189118/91487012-6cc41f00-e8ad-11ea-991b-c05e64e1a63b.png)

Seems to be a similar case as https://github.com/nvim-treesitter/nvim-treesitter/pull/341/files

```
LuaJIT 2.1.0-beta3 -- Copyright (C) 2005-2017 Mike Pall. http://luajit.org/
JIT: ON SSE2 SSE3 SSE4.1 BMI2 fold cse dce fwd dse narrow loop abc sink fuse
> a = {1, 4, 5}
> table.concat({nil, 3})
stdin:1: invalid value (nil) at index 1 in table for 'concat'
stack traceback:
        [C]: in function 'concat'
        stdin:1: in main chunk
        [C]: at 0x5624d470f1d0
> table.concat({nil, 'd'}, ' ')
stdin:1: invalid value (nil) at index 1 in table for 'concat'
stack traceback:
        [C]: in function 'concat'
        stdin:1: in main chunk
        [C]: at 0x5624d470f1d0
```