### PR TITLE
Add a extension module for vscode launch.json files

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -140,7 +140,25 @@ Things to note:
 - Some variables are supported:
 
   - `${file}`: Active filename
+  - `${workspaceFolder}`: The current working directory of Neovim
 
+
+==============================================================================
+DEBUGEE CONFIGURATION via launch.json                *dap-launch.json*
+
+nvim-dap supports a small subset of the `launch.json` file that is used to
+configure debug adapters in Visual Studio Code.
+
+To load the configurations, add the following in `init.vim`:
+
+>
+
+  lua require('dap.ext.vscode').load_launchjs()
+
+<
+
+This extends `dap.configurations` each time it is called, so make sure to only
+call it once.
 
 ==============================================================================
 MAPPINGS                                             *dap-mappings*

--- a/lua/dap/ext/vscode.lua
+++ b/lua/dap/ext/vscode.lua
@@ -1,0 +1,27 @@
+local dap = require('dap')
+local M = {}
+
+--- Extends dap.configurations with entries read from .vscode/launch.json
+--
+function M.load_launchjs(path)
+  local resolved_path = path or (vim.fn.getcwd() .. '/.vscode/launch.json')
+  local file = io.open(resolved_path)
+  if not file then
+    return
+  end
+  local contents = file:read("*all")
+  file:close()
+  local data = vim.fn.json_decode(contents)
+  assert(data.configurations, "launch.json must have a 'configurations' key")
+  for _, config in ipairs(data.configurations) do
+    assert(config.type, "Configuration in launch.json must have a 'type' key")
+    local configurations = dap.configurations[config.type]
+    if not configurations then
+      configurations = {}
+      dap.configurations[config.type] = configurations
+    end
+    table.insert(configurations, config)
+  end
+end
+
+return M


### PR DESCRIPTION
Allows to use the command:

    lua require('dap.ext.vscode').load_launchjs()

Within a `init.vim` or similar to read configuration entries from
`.vscode/launch.json`