### PR TITLE
Make vscode-go happy: Send source.name and lines in breakpoints

### DIFF
--- a/lua/dap/log.lua
+++ b/lua/dap/log.lua
@@ -28,7 +28,7 @@ function M.create_logger(filename)
   end
   local logfilename = path_join(vim.fn.stdpath('data'), filename)
 
-  local current_log_level = M.levels.WARN
+  local current_log_level = M.levels.INFO
 
   function logger.set_level(level)
     current_log_level = assert(


### PR DESCRIPTION
Lines is deprecated and optional in the spec, but without it setting breakpoints with `vscode-go` fails.

Without the `name` in source it also rejected the breakpoints. 