### PR TITLE
Skip frames without source when setting frame on stop

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -451,14 +451,19 @@ function Session:event_stopped(stopped)
       self.current_frame = nil
       threads[stopped.threadId].frames = frames
       for _, frame in pairs(frames_resp.stackFrames) do
-        if not current_frame then
+        if not current_frame and frame.source and frame.source.path then
           current_frame = frame
           self.current_frame = frame
         end
         table.insert(frames, frame)
       end
       if not current_frame then
-        return
+        if #frames > 0 then
+          current_frame = frames[1]
+          self.current_frame = current_frame
+        else
+          return
+        end
       end
       local preserve_focus
       if stopped.reason ~= 'pause' then


### PR DESCRIPTION
When debugging C++, this would avoid setting current frame to
a frame without source information. But instead go directly to
to lowest one with source code.

Should this behavior be configurable?

Example:
```
  ___lldb_unnamed_symbol9102$$libnvidia-glvkspirv.so.455.23.05
  ___lldb_unnamed_symbol8912$$libnvidia-glvkspirv.so.455.23.05
  ___lldb_unnamed_symbol8997$$libnvidia-glvkspirv.so.455.23.05
  ___lldb_unnamed_symbol8998$$libnvidia-glvkspirv.so.455.23.05
  ___lldb_unnamed_symbol8999$$libnvidia-glvkspirv.so.455.23.05
  ___lldb_unnamed_symbol9000$$libnvidia-glvkspirv.so.455.23.05
  _nv008nvvm
  ___lldb_unnamed_symbol51423$$libnvidia-glcore.so.455.23.05
  ___lldb_unnamed_symbol50266$$libnvidia-glcore.so.455.23.05
  ___lldb_unnamed_symbol50267$$libnvidia-glcore.so.455.23.05
  ___lldb_unnamed_symbol51451$$libnvidia-glcore.so.455.23.05
  ___lldb_unnamed_symbol51461$$libnvidia-glcore.so.455.23.05
  ___lldb_unnamed_symbol50330$$libnvidia-glcore.so.455.23.05
  ___lldb_unnamed_symbol50461$$libnvidia-glcore.so.455.23.05
  ___lldb_unnamed_symbol50516$$libnvidia-glcore.so.455.23.05
  ___lldb_unnamed_symbol50728$$libnvidia-glcore.so.455.23.05
→ vk::DispatchLoaderStatic::vkCreateComputePipelines(VkDevice_T*, VkPipelineCache_T*, unsigned int, VkComputePipelineCreateInfo const*, VkAllocationCallbacks const*, VkPipeline_T**) const
  vk::ResultValue<vk::UniqueHandle<vk::Pipeline, vk::DispatchLoaderStatic> > vk::Device::createComputePipelineUnique<vk::DispatchLoaderStatic>(vk::PipelineCache, vk::ComputePipelineCreateInfo const&, vk::Optional<vk::AllocationCallbacks const>, vk::DispatchLoaderStatic const&) const
  vk::Pipeline vuda::detail::kernelprogram<96ul>::CreatePipeline<long, long, long, long, long, long, long, long, long, long, long, double>(vk::UniqueHandle<vk::Device, vk::DispatchLoaderStatic> const&, vuda::detail::specialization<long, long, long, long, long, long, long, long, long, long, long, double> const&) const
  vk::Pipeline vuda::detail::kernelprogram<96ul>::GetSpecializedPipeline<long, long, long, long, long, long, long, long, long, long, long, double>(vk::UniqueHandle<vk::Device, vk::DispatchLoaderStatic> const&, vuda::detail::specialization<long, long, long, long, long, long, long, long, long, long, long, double> const&) const
  bool vuda::detail::kernelprogram<96ul>::UpdateDescriptorAndCommandBuffer<long, long, long, long, long, long, long, long, long, long, long, double, 3ul>(vk::UniqueHandle<vk::Device, vk::DispatchLoaderStatic> const&, vk::UniqueHandle<vk::CommandBuffer, vk::DispatchLoaderStatic> const&, std::array<vk::DescriptorBufferInfo, 3ul> const&, vuda::detail::specialization<long, long, long, long, long, long, long, long, long, long, long, double> const&, vuda::dim3) const
  void vuda::detail::thrdcmdpool::UpdateDescriptorAndCommandBuffer<96ul, long, long, long, long, long, long, long, long, long, long, long, double, 3ul>(vk::UniqueHandle<vk::Device, vk::DispatchLoaderStatic> const&, vuda::detail::kernelprogram<96ul> const&, vuda::detail::specialization<long, long, long, long, long, long, long, long, long, long, long, double> const&, std::array<vk::DescriptorBufferInfo, 3ul> const&, vuda::dim3, unsigned int) const
  void vuda::detail::logical_device::SubmitKernel<long, long, long, long, long, long, long, long, long, long, long, double, 3ul>(std::thread::id, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*, std::array<vk::DescriptorSetLayoutBinding, 3ul> const&, vuda::detail::specialization<long, long, long, long, long, long, long, long, long, long, long, double> const&, std::array<vk::DescriptorBufferInfo, 3ul> const&, vuda::dim3, unsigned int)
  void vuda::launchKernel<double*, double*, double*, long, long, long, long, long, long, long, long, long, long, long, double>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*, unsigned int, vuda::dim3, double*, double*, double*, long, long, long, long, long, long, long, long, long, long, long, double)
  walberla::pystencils::CumulantMRTSweep::operator()(walberla::domain_decomposition::IBlock*, unsigned int)
  void std::__invoke_impl<void, walberla::pystencils::CumulantMRTSweep&, walberla::domain_decomposition::IBlock*>(std::__invoke_other, walberla::pystencils::CumulantMRTSweep&, walberla::domain_decomposition::IBlock*&&)
  std::enable_if<is_invocable_r_v<void, walberla::pystencils::CumulantMRTSweep&, walberla::domain_decomposition::IBlock*>, void>::type std::__invoke_r<void, walberla::pystencils::CumulantMRTSweep&, walberla::domain_decomposition::IBlock*>(walberla::pystencils::CumulantMRTSweep&, walberla::domain_decomposition::IBlock*&&)
  std::_Function_handler<void (walberla::domain_decomposition::IBlock*), walberla::pystencils::CumulantMRTSweep>::_M_invoke(std::_Any_data const&, walberla::domain_decomposition::IBlock*&&)
  std::function<void (walberla::domain_decomposition::IBlock*)>::operator()(walberla::domain_decomposition::IBlock*) const
  walberla::timeloop::SweepTimeloop::doTimeStep(walberla::Set<walberla::uid::UID<walberla::uid::suidgenerator::S> > const&)
  walberla::timeloop::Timeloop::singleStep(bool)
  walberla::timeloop::Timeloop::run(bool)
  walberla::timeloop::Timeloop::run()
  walberla::main(int, char**)
  main
  __libc_start_main
  _start
```