### PR TITLE
Make pick_one function callback based

### DIFF
--- a/lua/dap/ui.lua
+++ b/lua/dap/ui.lua
@@ -1,22 +1,16 @@
 local M = {}
 
 
-function M.pick_one(items, prompt, label_fn)
-  if not items or #items == 0 then
-    return nil
-  end
-  if #items == 1 then
-    return items[1]
-  end
+function M.pick_one(items, prompt, label_fn, cb)
   local choices = {prompt}
   for i, item in ipairs(items) do
     table.insert(choices, string.format('%d: %s', i, label_fn(item)))
   end
   local choice = vim.fn.inputlist(choices)
   if choice < 1 or choice > #items then
-    return nil
+    return cb(nil)
   end
-  return items[choice]
+  return cb(items[choice])
 end
 
 


### PR DESCRIPTION
This will make it easier to monkey patch pick_one with a nicer
implemention. Most fuzzy finders are operating async with callback as
they make use of popups.

An alternative example implementation is available in nvim-fzy[1] that can
be used like this:

    lua require('dap.ui').pick_one = require('fzy').pick_one

[1]: https://github.com/mfussenegger/nvim-fzy