### PR TITLE
Give the adapter function access to the config

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -64,15 +64,16 @@ For `server` the following options are supported:
     port:  number       -- port to connect to
 
 
-`dap.adapters.<name>` can also be set to a function which takes one argument.
-This argument is a callback which must be called with the adapter table.
+`dap.adapters.<name>` can also be set to a function which takes two arguments.
+This first argument is a callback which must be called with the adapter table.
+The second argument is the configuration which will later be run.
 
 This can be used to defer the resolving of the values to when a configuration
 is used. An example use is java with eclipse.jdt.ls and java-debug, where the
 debug-adapter is spawned via a LSP command:
 >
 
-    dap.adapters.java = function(callback)
+    dap.adapters.java = function(callback, config)
       M.execute_command({command = 'vscode.java.startDebugSession'}, function(err0, port)
         assert(not err0, vim.inspect(err0))
 

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -189,15 +189,17 @@ function M.run(config, opts)
   if opts.before then
     config = opts.before(config)
   end
+  config = vim.tbl_map(expand_config_variables, config)
   local adapter = M.adapters[config.type]
   if type(adapter) == 'table' then
-    config = vim.tbl_map(expand_config_variables, config)
     maybe_enrich_config_and_run(adapter, config, opts)
   elseif type(adapter) == 'function' then
-    adapter(function(resolved_adapter)
-      config = vim.tbl_map(expand_config_variables, config)
-      maybe_enrich_config_and_run(resolved_adapter, config, opts)
-    end)
+    adapter(
+      function(resolved_adapter)
+        maybe_enrich_config_and_run(resolved_adapter, config, opts)
+      end,
+      config
+    )
   else
     print('Invalid adapter: ', vim.inspect(adapter))
   end


### PR DESCRIPTION
This will allow to run pre-hooks or start the adapter differently
depending on options in the configuration.

For example, debugpy has an example in the wiki[1] that translates to
roughly the following adapter implementation:

```lua
dap.adapters.python = function(cb, config)
  if config.request == 'attach' then
    cb({
      type = 'server';
      port = config.port or 0;
      host = config.host or '127.0.0.1';
    })
  else
    cb({
      type = 'executable';
      command = HOME .. '/.virtualenvs/tools/bin/python';
      args = { '-m', 'debugpy.adapter' };
    })
  end
end
```

[1]: https://github.com/microsoft/debugpy/wiki/DAP-Client-reference#vs-code-debugadapterdescriptor
