### PR TITLE
Spawn child process detached

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -859,6 +859,7 @@ function Session:spawn(adapter, opts)
     stdio = {stdin, stdout, stderr};
     cwd = options.cwd;
     env = options.env;
+    detached = true;
   }, onexit)
   assert(handle, 'Error running ' .. adapter.command .. ': ' .. pid_or_err)
   o.client = {
@@ -1348,4 +1349,13 @@ function M.set_log_level(level)
 end
 
 
+function M._vim_exit_handler()
+  if session then
+    session:close()
+  end
+end
+dap._vim_exit_handler = M._vim_exit_handler  -- luacheck: ignore 112
+
+
+api.nvim_command("autocmd VimLeavePre * lua dap._vim_exit_handler()")
 return M


### PR DESCRIPTION
To avoid things like done in [debugpy][1] from affecting neovim

Should fix #59

[1]: https://github.com/microsoft/debugpy/commit/5087603ea3db9596960d7477633ba189debda1c6