### PR TITLE
Add a `wincmd` argument to repl.open/toggle

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -388,6 +388,9 @@ repl.open({winopts})                                           *dap.repl.open()*
             {winopts}  optional table which may include:
                         `height` to set the window height
                         `width` to set the window width
+                        `wincmd` command that is used to create the window for
+                        the REPL. Defaults to 'belowright split'
+
                         Any other key/value pair, that will be treated as window
                         option.
 

--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -381,18 +381,19 @@ goto_({line})                                                      *dap.goto_()*
             {line}  Line number or line under cursor if nil.
 
 
-repl.open({winopts})                                           *dap.repl.open()*
+repl.open({winopts}, {wincmd})                                 *dap.repl.open()*
         Open a REPL / Debug-console.
 
         Parameters: ~
             {winopts}  optional table which may include:
                         `height` to set the window height
                         `width` to set the window width
-                        `wincmd` command that is used to create the window for
-                        the REPL. Defaults to 'belowright split'
-
                         Any other key/value pair, that will be treated as window
                         option.
+
+            {wincmd} command that is used to create the window for
+                     the REPL. Defaults to 'belowright split'
+
 
         The REPL can be used to evaluate expressions. A `omnifunc` is set to
         support completion of expressions. It supports the following special
@@ -442,7 +443,7 @@ repl.open({winopts})                                           *dap.repl.open()*
         <
 
 
-repl.toggle({winopts})                                       *dap.repl.toggle()*
+repl.toggle({winopts}, {wincmd})                             *dap.repl.toggle()*
         Opens the REPL if it is closed, otherwise closes it.
 
         See |dap.repl.open| for a description of the argument.

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -212,6 +212,9 @@ end
 --@param winopts  optional table which may include:
 --                  `height` to set the window height
 --                  `width` to set the window width
+--                  'wincmd' command that is used to create the window for the
+--                  REPL.  Defaults to 'belowright split'
+--
 --                  Any other key/value pair, that will be treated as window
 --                  option.
 function M.open(winopts)
@@ -250,23 +253,23 @@ function M.open(winopts)
     })
   end
   local current_win = api.nvim_get_current_win()
-  api.nvim_command('belowright split')
+  winopts = winopts or {}
+  assert(
+    type(winopts) == 'table',
+    'winopts must be a table, not ' .. type(winopts) .. ': ' .. vim.inspect(winopts)
+  )
+  api.nvim_command(winopts.wincmd or 'belowright split')
+  winopts.wincmd = nil
   win = api.nvim_get_current_win()
   api.nvim_win_set_buf(win, buf)
   api.nvim_set_current_win(current_win)
-  if winopts then
-    assert(
-      type(winopts) == 'table',
-      'winopts must be a table, not ' .. type(winopts) .. ': ' .. vim.inspect(winopts)
-    )
-    for k, v in pairs(winopts) do
-      if k == 'width' then
-        api.nvim_win_set_width(win, v)
-      elseif k == 'height' then
-        api.nvim_win_set_height(win, v)
-      else
-        api.nvim_win_set_option(win, k, v)
-      end
+  for k, v in pairs(winopts) do
+    if k == 'width' then
+      api.nvim_win_set_width(win, v)
+    elseif k == 'height' then
+      api.nvim_win_set_height(win, v)
+    else
+      api.nvim_win_set_option(win, k, v)
     end
   end
 end

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -212,12 +212,13 @@ end
 --@param winopts  optional table which may include:
 --                  `height` to set the window height
 --                  `width` to set the window width
---                  'wincmd' command that is used to create the window for the
---                  REPL.  Defaults to 'belowright split'
 --
 --                  Any other key/value pair, that will be treated as window
 --                  option.
-function M.open(winopts)
+--
+--@param wincmd command that is used to create the window for the REPL.
+--              Defaults to 'belowright split'
+function M.open(winopts, wincmd)
   if win and api.nvim_win_is_valid(win) and api.nvim_win_get_buf(win) == buf then
     return
   end
@@ -253,32 +254,33 @@ function M.open(winopts)
     })
   end
   local current_win = api.nvim_get_current_win()
-  winopts = winopts or {}
-  assert(
-    type(winopts) == 'table',
-    'winopts must be a table, not ' .. type(winopts) .. ': ' .. vim.inspect(winopts)
-  )
-  api.nvim_command(winopts.wincmd or 'belowright split')
-  winopts.wincmd = nil
+  assert(not wincmd or type(wincmd) == 'string', 'wincmd must be nil or a string')
+  api.nvim_command(wincmd or 'belowright split')
   win = api.nvim_get_current_win()
   api.nvim_win_set_buf(win, buf)
   api.nvim_set_current_win(current_win)
-  for k, v in pairs(winopts) do
-    if k == 'width' then
-      api.nvim_win_set_width(win, v)
-    elseif k == 'height' then
-      api.nvim_win_set_height(win, v)
-    else
-      api.nvim_win_set_option(win, k, v)
+  if winopts then
+    assert(
+      type(winopts) == 'table',
+      'winopts must be a table, not ' .. type(winopts) .. ': ' .. vim.inspect(winopts)
+    )
+    for k, v in pairs(winopts) do
+      if k == 'width' then
+        api.nvim_win_set_width(win, v)
+      elseif k == 'height' then
+        api.nvim_win_set_height(win, v)
+      else
+        api.nvim_win_set_option(win, k, v)
+      end
     end
   end
 end
 
 
 --- Open the REPL if it is closed, close it if it is open.
-function M.toggle(winopts)
+function M.toggle(winopts, wincmd)
   if not M.close() then
-    M.open(winopts)
+    M.open(winopts, wincmd)
   end
 end
 


### PR DESCRIPTION
Allows users to customize where the REPL is opened.
An example use:

    :lua require('dap').repl.open({ wincmd = 'vsplit' })

Closes https://github.com/mfussenegger/nvim-dap/issues/79

---

**Update**

Changed it to `open(<winopts>, <wincmd>)`:

    :lua require('dap').repl.open({}, 'vsplit')

