### PR TITLE
Change logfile path to XDG_CACHE_HOME

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -520,12 +520,12 @@ set_log_level(level)                                       *dap.set_log_level()*
           WARN
           ERROR
 
-        The log file is in the |stdpath| `data` folder.
+        The log file is in the |stdpath| `cache` folder.
         To print the location:  >
 
-            :lua print(vim.fn.stdpath('data'))
+            :lua print(vim.fn.stdpath('cache'))
 <
-        The filename is `nvim-dap.log`
+        The filename is `dap.log`
 
 
 session()                                                        *dap.session()*

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -3,7 +3,7 @@ dap = {} -- luacheck: ignore 111 - to support v:lua.dap... uses
 
 local uv = vim.loop
 local api = vim.api
-local log = require('dap.log').create_logger('vim-dap.log')
+local log = require('dap.log').create_logger('dap.log')
 local ui = require('dap.ui')
 local repl = require('dap.repl')
 local M = {}

--- a/lua/dap/log.lua
+++ b/lua/dap/log.lua
@@ -26,7 +26,7 @@ function M.create_logger(filename)
   local function path_join(...)
     return table.concat(vim.tbl_flatten{...}, path_sep)
   end
-  local logfilename = path_join(vim.fn.stdpath('data'), filename)
+  local logfilename = path_join(vim.fn.stdpath('cache'), filename)
 
   local current_log_level = M.levels.INFO
 
@@ -41,7 +41,7 @@ function M.create_logger(filename)
     return logfilename
   end
 
-  vim.fn.mkdir(vim.fn.stdpath('data'), "p")
+  vim.fn.mkdir(vim.fn.stdpath('cache'), "p")
   local logfile = assert(io.open(logfilename, "a+"))
   for level, levelnr in pairs(M.levels) do
     logger[level:lower()] = function(...)


### PR DESCRIPTION
Follows the upstream change, so that the `dap.log` is in the same folder
as the `lsp.log`:

https://github.com/neovim/neovim/commit/ea8756f85ddd0aeed2e7eccd0ea86ade4fb7eca8