### PR TITLE
fix(variables): remove erroneous syntax match

### DIFF
--- a/syntax/dap-variables.vim
+++ b/syntax/dap-variables.vim
@@ -4,7 +4,6 @@ endif
 
 syn match DapVariableTreeType "[a-zA-Z0-9_<>]\+$"
 syn match DapVariableTreeOperator "[=:]\s"
-syn match DapVariableTreeNumber "[0.9[.0-9]"
 syn region DapVariableTreeString start=+"+ end=+"+ end=+$+
 syn region DapVariableTreeString start=+'+ end=+'+ end=+$+
 


### PR DESCRIPTION
I think this line is not needed any more since I copied the number matches from python.vim