### PR TITLE
feat(variable hover): add function to toggle multi-line display

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -546,8 +546,16 @@ The methods listed here are in the `dap.ui.variables` module. To use them you ha
 <
 
 
-hover()                                             *dap.ui.variables.hover()*
+hover()                                               *dap.ui.variables.hover()*
         Opens a floating window with information about the variable under the
         cursor.
 
         Requires an active debug session.
+
+toggle_multiline_display({value})  *dap.ui.variables.toggle_multiline_display()*
+        Toggles between single and multi-line variable display in the variable
+        hover window or sets multi-line display on or off when `{values}` is
+        provided.
+
+        This functionality is also available by pressing "g?" in normal mode
+        in a hover window.

--- a/syntax/dap-variables.vim
+++ b/syntax/dap-variables.vim
@@ -4,8 +4,8 @@ endif
 
 syn match DapVariableTreeType "[a-zA-Z0-9_<>]\+$"
 syn match DapVariableTreeOperator "[=:]\s"
-syn region DapVariableTreeString start=+"+ end=+"+ end=+$+
-syn region DapVariableTreeString start=+'+ end=+'+ end=+$+
+syn region DapVariableTreeString start=+"+ skip=+\\\\\|\\"+ end=+"+
+syn region DapVariableTreeString start=+'+ skip=+\\\\\|\\'+ end=+'+
 
 " From Python syntax
 syn match   DapVariableTreeNumber	"\<0[oO]\=\o\+[Ll]\=\>"


### PR DESCRIPTION
Add a function to toggle multiline display in the variable hover window (also available as `?` keymap in hover window). Useful for inspecting stacktraces and multi-line strings. Some object representations can get pretty long this is why single line display is the default.


https://user-images.githubusercontent.com/7189118/105631194-87df8e80-5e4d-11eb-95f6-aa31a42a3d38.mp4

https://user-images.githubusercontent.com/7189118/105631183-7f875380-5e4d-11eb-8b6d-4a10ecb2d626.mp4


