### PR TITLE
variables: Enable dynamic evaluation with customizable function

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -548,7 +548,7 @@ The methods listed here are in the `dap.ui.variables` module. To use them you ha
 
 hover()                                               *dap.ui.variables.hover()*
         Opens a floating window with information about the variable under the
-        cursor.
+        cursor or the current visual selection.
 
         Requires an active debug session.
 

--- a/lua/dap/utils.lua
+++ b/lua/dap/utils.lua
@@ -29,4 +29,37 @@ function M.index_of(items, predicate)
 end
 
 
+----- Get a ts compatible range of the current visual selection.
+----
+---- The range of ts nodes start with 0 and the ending range is exclusive.
+function M.visual_selection_range()
+  local _, csrow, cscol, _ = unpack(vim.fn.getpos("'<"))
+  local _, cerow, cecol, _ = unpack(vim.fn.getpos("'>"))
+  if csrow < cerow or (csrow == cerow and cscol <= cecol) then
+    return csrow - 1, cscol - 1, cerow - 1, cecol
+  else
+    return cerow - 1, cecol - 1, csrow - 1, cscol
+  end
+end
+
+
+---- Returns visual selection if it exists or nil
+function M.get_visual_selection_text()
+  local bufnr = vim.api.nvim_get_current_buf()
+
+  -- We have to remember that end_col is end-exclusive
+  local start_row, start_col, end_row, end_col = M.visual_selection_range()
+
+  if start_row ~= end_row then
+    local lines = vim.api.nvim_buf_get_lines(bufnr, start_row, end_row+1, false)
+    lines[1] = string.sub(lines[1], start_col+1)
+    lines[#lines] = string.sub(lines[#lines], 1, end_col)
+    return table.concat(lines, '\n')
+  else
+    local line = vim.api.nvim_buf_get_lines(bufnr, start_row, start_row+1, false)[1]
+    -- If line is nil then the line is empty
+    return line and table.concat({ string.sub(line, start_col+1, end_col) }, '\n')
+  end
+end
+
 return M


### PR DESCRIPTION
New default for evaluation expression is visual selection or `cword`

This enable inspecting of member functions without explicit `this`

![Screenshot_20210202_203301](https://user-images.githubusercontent.com/7189118/106655756-0fd63e80-659a-11eb-9236-e0927e68627f.png)

Or evaluation from visual selection

![image](https://user-images.githubusercontent.com/7189118/106655553-ce459380-6599-11eb-80e3-2ec11be33785.png)
when selecting `this->m_member`
![image](https://user-images.githubusercontent.com/7189118/106656165-99860c00-659a-11eb-9192-8808c4d2dbfc.png)


The functions for visual selection come from nvim-treesitter. I wrote the one that gives you the text from the range.

You can replace the function for the current expression to evaluate if you want to.

