### PR TITLE
Disable jscpd linting

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,3 +19,4 @@ jobs:
         uses: github/super-linter@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_JSCPD: false


### PR DESCRIPTION
Bad abstractions are worse than a bit of code duplication