### PR TITLE
Nat sort

### DIFF
--- a/lua/dap/ui/variables.lua
+++ b/lua/dap/ui/variables.lua
@@ -39,7 +39,13 @@ local function write_variables(buf, variables, line, column, win)
   table.sort(
     sorted_variables,
     function(a, b)
-      return a.name < b.name
+      local num_a = string.match(a.name, '^%[?(%d+)%]?$')
+      local num_b = string.match(b.name, '^%[?(%d+)%]?$')
+      if num_a and num_b then
+        return tonumber(num_a) < tonumber(num_b)
+      else
+        return a.name < b.name
+      end
     end
   )
   local max_textlength = 0


### PR DESCRIPTION
Default sorting in the variable window is by character. This can mess up the order or array indices

![Screenshot_20210202_215935](https://user-images.githubusercontent.com/7189118/106662711-07363600-65a3-11eb-813f-e5be36a545c4.png)

I don't know whether we should switch to a natural sort order by padding all numbers in variable names with zeros???
![image](https://user-images.githubusercontent.com/7189118/106662658-f4236600-65a2-11eb-9fbc-0f8661ef5e0b.png)

