### PR TITLE
Add a trigger character based autocompletion extension

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -235,6 +235,25 @@ An example:
 <
 
 ==============================================================================
+REPL COMPLETION                                               *dap-completion*
+
+
+nvim-dap includes an omnifunc implementation which uses the active debug
+session to get completion candidates.
+
+It is by default set within the REPL which means you can use `CTRL-X CTRL-O` to
+trigger completion within the REPL.
+
+You can also setup the completion to trigger automatically:
+
+>
+  au FileType dap-repl lua require('dap.ext.autocompl').attach()
+<
+
+Completion will then trigger automatically on any of the completion trigger
+characters reported by the debug adapter or if none are reported on `.`.
+
+==============================================================================
 MAPPINGS                                             *dap-mappings*
 
 

--- a/lua/dap/ext/autocompl.lua
+++ b/lua/dap/ext/autocompl.lua
@@ -1,0 +1,58 @@
+local M = {}
+local api = vim.api
+local dap = require('dap')
+local timer = nil
+
+
+local function destroy_timer()
+  if timer then
+    timer:stop()
+    timer:close()
+    timer = nil
+  end
+end
+
+
+local function trigger_completion()
+  dap.omnifunc(1, "")
+end
+
+
+function M._InsertCharPre()
+  destroy_timer()
+  local char = api.nvim_get_vvar('char')
+  if tonumber(vim.fn.pumvisible()) == 1 then
+    return
+  end
+  local session = dap.session()
+  if not session then
+    return
+  end
+  local capabilities = session.capabilities or {}
+  local triggers = capabilities.completionTriggerCharacters or {'.'}
+  if vim.tbl_contains(triggers, char) then
+    timer = vim.loop.new_timer()
+    timer:start(150, 0, vim.schedule_wrap(trigger_completion))
+  end
+end
+
+
+function M._InsertLeave()
+  destroy_timer()
+end
+
+
+function M.attach(bufnr)
+  bufnr = bufnr or api.nvim_get_current_buf()
+  vim.cmd(string.format(
+    "autocmd InsertCharPre <buffer=%d> lua require('dap.ext.autocompl')._InsertCharPre()",
+    bufnr
+  ))
+  vim.cmd(string.format(
+    "autocmd InsertLeave <buffer=%d> lua require('dap.ext.autocompl')._InsertLeave()",
+    bufnr
+  ))
+end
+
+
+return M


### PR DESCRIPTION
This is quite minimal, all it does is trigger the omnifunc if any of the
trigger characters is typed in insert mode.

The dap omnifunc implementation is async, so this is non-blocking and
should be fast.

This should provide a good experience without dap turning into a full
blown autocompletion plugin.

It is opt-in so users could also use their prefered completion plugin with the omnifunction


https://user-images.githubusercontent.com/38700/107116178-c889cf80-6871-11eb-80d3-02a558ef21d1.mp4

