### PR TITLE
Variable frames

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -574,6 +574,16 @@ hover()                                               *dap.ui.variables.hover()*
 
         Requires an active debug session.
 
+scopes()                                            *dap.ui.variables.scopes()*
+        Opens a hover with all variable scopes of the current frame.
+
+        Requires an active debug session.
+
+frames()                                            *dap.ui.variables.frames()*
+        Opens a hover with the variable of all frames.
+
+        Requires an active debug session.
+
 visual_hover()                                 *dap.ui.variables.visual_hover()*
         Opens a floating window with information on the value of the 
         current visual selection.

--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -580,7 +580,7 @@ scopes()                                            *dap.ui.variables.scopes()*
         Requires an active debug session.
 
 frames()                                            *dap.ui.variables.frames()*
-        Opens a hover with the variable of all frames.
+        Opens a hover with the variables of all frames as a tree.
 
         Requires an active debug session.
 

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -600,8 +600,8 @@ function Session.event_output(_, body)
   repl.append(body.output, '$')
 end
 
-function Session:_request_scopes(current_frame)
-  self:request('scopes', { frameId = current_frame.id }, function(_, scopes_resp)
+function Session:_request_scopes(current_frame, callback)
+  self:request('scopes', { frameId = current_frame.id }, function(err, scopes_resp)
     if not scopes_resp or not scopes_resp.scopes then return end
 
     current_frame.scopes = {}
@@ -618,6 +618,9 @@ function Session:_request_scopes(current_frame)
           )
         end)
       end
+    end
+    if callback then
+      callback(err, scopes_resp)
     end
   end)
 end

--- a/lua/dap/ui/variables.lua
+++ b/lua/dap/ui/variables.lua
@@ -108,7 +108,7 @@ function M.toggle_variable_expanded()
 
   local v = state.line_to_variable[pos[1] - 1]
 
-  if v and v.variablesReference > 0 then
+  if v and v.variablesReference ~= 0 then
     if state.expanded[v.variablesReference] then
       state.expanded[v.variablesReference] = nil
       update_variable_buffer(buf, win)
@@ -155,7 +155,7 @@ local function create_variable_buffer(buf, win, session, root_variables)
   }
   for _, v in pairs(root_variables) do
     -- Is variable expandable?
-    if v.variablesReference and v.variablesReference > 0 then
+    if v.variablesReference and v.variablesReference ~= 0 then
       variable_buffers[buf].expanded[v.variablesReference] = true
       if not v.variables then
         session:request(
@@ -248,16 +248,16 @@ function M.frames()
     local node = {
       name = f.name,
       variables = f.scopes,
-      variablesReference = f.id,
+      variablesReference = -f.id, -- use negative id to not collide with variablesReference
     }
 
     if not f.scopes or #f.scopes == 0 then
-       session:_request_scopes(f, function(_, resp)
-         if resp then
-           node.variables = resp.scopes
-           update_variable_buffer(floating_buf, floating_win)
-         end
-       end)
+      session:_request_scopes(f, function(_, resp)
+        if resp then
+          node.variables = resp.scopes
+          update_variable_buffer(floating_buf, floating_win)
+        end
+      end)
     end
     table.insert(tree, node)
   end
@@ -268,8 +268,6 @@ end
 
 function M.scopes()
   if not is_stopped_at_frame() then return end
-
-  local session = require('dap').session()
 
   local session = require('dap').session()
 

--- a/lua/dap/utils.lua
+++ b/lua/dap/utils.lua
@@ -8,7 +8,7 @@ local M = {}
 function M.to_dict(values, get_key, get_value)
   local rtn = {}
   get_value = get_value or function(v) return v end
-  for _, v in pairs(values) do
+  for _, v in pairs(values or {}) do
     rtn[get_key(v)] = get_value(v)
   end
   return rtn


### PR DESCRIPTION
This is a follow up of #105 showing the variables of all frames as a tree.

![Screenshot_20210207_002610](https://user-images.githubusercontent.com/7189118/107132140-b5f8b000-68dc-11eb-87c1-2ca2f20feb25.png)


Some debug adapter can evaluate the variables of different frames while without switching the current frame. Might be useful when browsing for something specific across many frames
![Screenshot_20210207_003106](https://user-images.githubusercontent.com/7189118/107132092-75009b80-68dc-11eb-88e8-a7df76144144.png)

