### PR TITLE
fix: do not pass vim.empty_dict() to uv.spawn

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -955,7 +955,7 @@ function Session:spawn(adapter, opts)
     args = adapter.args;
     stdio = {stdin, stdout, stderr};
     cwd = options.cwd;
-    env = non_empty(options.env) and options.env or vim.empty_dict();
+    env = options.env;
     detached = true;
   }, onexit)
   assert(handle, 'Error running ' .. adapter.command .. ': ' .. pid_or_err)


### PR DESCRIPTION
The change to use vim.empty_dict() was necessary for jobstart but
not for uv.spawn. This prevented me from starting debugpy.