### PR TITLE
Hover: Use <cexpr> instead of <cword>

### DIFF
--- a/lua/dap/ui/variables.lua
+++ b/lua/dap/ui/variables.lua
@@ -213,7 +213,7 @@ end
 
 
 function M.resolve_expression()
-  return vim.fn.expand("<cword>")
+  return vim.fn.expand("<cexpr>")
 end
 
 


### PR DESCRIPTION
Hi @mfussenegger ,

Thanks for providing this nice plugin!

I've noticed, that you use `<cword>` for the hover functionality. This doesn't work well for nested properties, e.g.
```js
myObject.myProperty
//       ^^^^^^^^^^ you hover here
```
In this example, `hover` would be called with `myProperty` leading to an error.

Vim has also `<cexpr>` which does the trick, yielding `myObject.myProperty`.
See `:h <cexpr>` for more information.

I've created this PR to change the behaviour, feel free to reach out to me if you have any questions.

I also created a small video showing this in action:
https://youtu.be/ga3Cas7vNCk

Best regards,
David

<img width="1894" alt="example" src="https://user-images.githubusercontent.com/1009936/107870726-3ac66980-6e9b-11eb-94da-1b67b3c6e6b7.png">


