### PR TITLE
Workaround for empty setBreakpoints response

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -756,13 +756,18 @@ function Session:set_breakpoints(bufexpr, on_done)
     self:request('setBreakpoints', payload, function(err1, resp)
         if err1 then
           print("Error setting breakpoints: " .. err1.message)
-        else
+        elseif resp then
           for _, bp in pairs(resp.breakpoints) do
             if not bp.verified then
               log.info('Server rejected breakpoint', bp)
               remove_breakpoint_signs(bufnr, bp.line)
             end
           end
+        else
+          log.warn(
+            'setBreakpoints response contains neither an error nor a body. ' ..
+            'This is likely a bug in the debug adapter.'
+          )
         end
         num_bufs = num_bufs - 1
         if num_bufs == 0 and on_done then


### PR DESCRIPTION
Looks like `delve` can send a response that is `nil`:

```
.config/nvim/pack/plugins/start/nvim-dap/lua/dap.lua:760: attempt to index local 'resp' (a nil value)
```

This is with the following adapter config:

```lua
  dap.adapters.go = {
    type = 'server',
    host = '127.0.0.1',
    port = 46545
  }
```

https://user-images.githubusercontent.com/38700/109873407-fcd48e00-7c6d-11eb-8eef-108b8a3d56c2.mp4
