### PR TITLE
Do not set seq based on server responses

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -833,7 +833,6 @@ end
 
 function Session:handle_body(body)
   local decoded = convert_nil(vim.fn.json_decode(body))
-  self.seq = decoded.seq + 1
   local _ = log.debug() and log.debug(decoded)
   if decoded.request_seq then
     local callback = self.message_callbacks[decoded.request_seq]


### PR DESCRIPTION
delve always returns 0 as `seq` in their reponses, that reset the
counter and led to duplicate `request_seq` numbers, which broke the
callback selection.