### PR TITLE
fix: call custom events first

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -859,10 +859,10 @@ function Session:handle_body(body)
     local callback = self['event_' .. decoded.event]
     if callback then
       vim.schedule(function()
-        callback(self, decoded.body)
         for _, c in pairs(M.custom_event_handlers['event_' .. decoded.event]) do
           c(self, decoded.body)
         end
+        callback(self, decoded.body)
       end)
     else
       log.warn('No event handler for ', decoded)


### PR DESCRIPTION
Following on from the discussion on #121, I've attempted to do something like
```lua
      before = function(config)
        dap.custom_event_handlers.event_output[handler_id] = output_handler
        dap.custom_event_handlers.event_terminated[handler_id] = terminated_handler
        dap.custom_event_handlers.event_exited[handler_id] = exit_handler
        return config
      end,
      after = function()
        dap.custom_event_handlers.event_exited[handler_id] = nil
        dap.custom_event_handlers.event_terminated[handler_id] = nil
        dap.custom_event_handlers.event_output[handler_id] = nil
      end
```
However, nvim-dap also handles the terminated event and calls the `after` function which means the terminated handler is removed before being used. So I just changed it to call custom handlers first, though I'm not sure if this will break something in other plugins that rely on dap having done some handling first... Any concerns?