### PR TITLE
fix: dapl.repl.run_last to dap.run_last in example mappings

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -268,7 +268,7 @@ Some example mappings:
     nnoremap <silent> <leader>B :lua require'dap'.set_breakpoint(vim.fn.input('Breakpoint condition: '))<CR>
     nnoremap <silent> <leader>lp :lua require'dap'.set_breakpoint(nil, nil, vim.fn.input('Log point message: '))<CR>
     nnoremap <silent> <leader>dr :lua require'dap'.repl.open()<CR>
-    nnoremap <silent> <leader>dl :lua require'dap'.repl.run_last()<CR>
+    nnoremap <silent> <leader>dl :lua require'dap'.run_last()<CR>
 
 
 ==============================================================================


### PR DESCRIPTION
This little line caused me some unfortunate headaches in setting up my mappings :sweat_smile: