### PR TITLE
fix: call read_start once connected

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -891,8 +891,8 @@ function Session:connect(host, port, opts)
   }
   client:connect(host or '127.0.0.1', tonumber(port), function(err)
     if (err) then print(err) end
+    client:read_start(rpc.create_read_loop(function(body) session:handle_body(body) end))
   end)
-  client:read_start(rpc.create_read_loop(function(body) session:handle_body(body) end))
   return o
 end
 


### PR DESCRIPTION
I have been playing around with nvim-dap and an lua adapter for it. TCP communication got me stuck for a good moment but I think this fixes it. This calls `read_start` once in the `connect` callback. Similar to [here](https://github.com/luvit/luv/blob/master/examples/uvbook/tcp-echo-client.lua).