### PR TITLE
Fix #138: Make stepInTargets an explicit command

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -436,33 +436,43 @@ set_exception_breakpoints({filters}, {exceptionOptions})
     |dap-configuration| or the |dap-adapter| definition.
 
 
-step_over()                                                    *dap.step_over()*
+step_over([{opts}])                                            *dap.step_over()*
         Requests the debugee to run again for one step.
 
+        For {opts} see |step_into|.
 
-step_into()                                                    *dap.step_into()*
+
+step_into([{opts}])                                            *dap.step_into()*
         Requests the debugee to step into a function or method if possible.
         If it cannot step into a function or method it behaves like
         |dap.step_over()|.
 
-        Some debug adapters allow a more fine-grained control over the
-        behavior of this command:
+        If the debug adapter has the `supportsStepInTargetsRequest` and  
+        {ask_for_targets} is true, the user can choose into which function they
+        want to step into if there are multiple.
 
-        dap.defaults.fallback.stepping_granularity:
+        Some debug adapters allow a more fine-grained control over the
+        behavior of this command using the {opts} parameter:
+
+        steppingGranularity:
           Can be 'statement' | 'line' | 'instruction'
+          Will fall back to dap.defaults.fallback.stepping_granularity
           Default: 'statement'
 
-        dap.defaults.fallback.ask_step_in_targets:
-          Can be true or false. If true and the debug adapter has the
-          supportsStepInTargetsRequest capability it will ask the user
-          to choose if there are multiple functions to step into in one line.
-          Default: true
+        askForTargets:
+          Ask the user to step into which function if there are multiple choices.
+          Only for step_into.
 
-step_out()                                                      *dap.step_out()*
+
+step_out([{opts}])                                              *dap.step_out()*
         Requests the debugee to step out of a function or method if possible.
 
-step_back()                                                    *dap.step_back()*
+        For options see |step_into|.
+
+step_back([{opts}]                                             *dap.step_back()*
         Steps one step back. Debug adapter must support reverse debugging.
+
+        For {opts} see |step_into|.
 
 pause({thread_id})                                                 *dap.pause()*
         Requests debug adapter to pause a thread. If there are multiple threads
@@ -509,6 +519,7 @@ repl.open({winopts}, {wincmd})                                 *dap.repl.open()*
           .c or .continue     Same as |dap.continue|
           .n or .next         Same as |dap.step_over|
           .into               Same as |dap.step_into|
+          .into_target        Same as |dap.step_into{askForTargets=true}|
           .out                Same as |dap.step_out|
           .up                 Same as |dap.up|
           .down               Same as |dap.down|
@@ -529,6 +540,7 @@ repl.open({winopts}, {wincmd})                                 *dap.repl.open()*
             back = {'.back', '.b'},
             reverse_continue = {'.reverse-continue', '.rc'},
             into = {'.into'},
+            into_target = {'.into_target'},
             out = {'.out'},
             scopes = {'.scopes'},
             threads = {'.threads'},

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -40,7 +40,6 @@ M.defaults = setmetatable(
   {
     fallback = {
       exception_breakpoints = 'default';
-      ask_step_in_targets = true;
       -- type SteppingGranularity = 'statement' | 'line' | 'instruction'
       stepping_granularity = 'statement';
     },
@@ -1026,16 +1025,18 @@ function Session:_step(step, params)
   end)
 end
 
-function M.step_over()
+function M.step_over(opts)
   if not session then return end
-  session:_step('next')
+  session:_step('next', opts)
 end
 
-function M.step_into()
+function M.step_into(opts)
   if not session then return end
-  local ask_targets = M.defaults[session.config.type].ask_step_in_targets
-  if not (ask_targets and session.capabilities.supportsStepInTargetsRequest) then
-    session:_step('stepIn')
+  opts = opts or {}
+  local askForTargets = opts.askForTargets
+  opts.askForTargets = nil
+  if not (askForTargets and session.capabilities.supportsStepInTargetsRequest) then
+    session:_step('stepIn', opts)
     return
   end
 
@@ -1053,31 +1054,32 @@ function M.step_into()
         if not target or not target.id then
           print('No target selected. No stepping.')
         else
-          session:_step('stepIn', { target_id = target.id })
+          opts.targetId = target.id
+          session:_step('stepIn', opts)
         end
       end)
   end)
 end
 
-function M.step_out()
+function M.step_out(opts)
   if not session then return end
-  session:_step('stepOut')
+  session:_step('stepOut', opts)
 end
 
-function M.step_back()
+function M.step_back(opts)
   if not session then return end
 
   if session.capabilities.supportsStepBack then
-    session:_step('stepBack')
+    session:_step('stepBack', opts)
   else
     print("Debug Adapter does not support stepping backwards.")
   end
 end
 
-function M.reverse_continue()
+function M.reverse_continue(opts)
   if not session then return end
   if session.capabilities.supportsStepBack then
-    session:_step('reverseContinue')
+    session:_step('reverseContinue', opts)
   else
     print("Debug Adapter does not support stepping backwards.")
   end

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -23,6 +23,7 @@ M.commands = {
   step_back = {'.back', '.b'},
   reverse_continue = {'.reverse-continue', '.rc'},
   into = {'.into'},
+  into_targets = {'.into-targets'},
   out = {'.out'},
   scopes = {'.scopes'},
   threads = {'.threads'},
@@ -136,6 +137,8 @@ local function execute(text)
     M.append(vim.inspect(session.capabilities))
   elseif vim.tbl_contains(M.commands.into, text) then
     require('dap').step_into()
+  elseif vim.tbl_contains(M.commands.into_targets, text) then
+    require('dap').step_into({askForTargets=true})
   elseif vim.tbl_contains(M.commands.out, text) then
     require('dap').step_out()
   elseif vim.tbl_contains(M.commands.up, text) then


### PR DESCRIPTION
We could also keep the current behavior and but only accept target in the same line or the same statement. I just had the feeling that when you can step into any arbitrary function in the stack frame it would be different enough that the user would like to have both normal stepIn and stepIn with targets.

I don't know whether this is the best strategy. The protocol is very flexible on when its about what adapter should return and how debugger should use the response best in its UI.