### PR TITLE
Fix repl modified handling

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -1402,6 +1402,7 @@ function M._vim_exit_handler()
   if session then
     session:close()
   end
+  repl.close()
 end
 
 
@@ -1411,5 +1412,5 @@ function M.session()
 end
 
 
-api.nvim_command("autocmd VimLeavePre * lua require('dap')._vim_exit_handler()")
+api.nvim_command("autocmd ExitPre * lua require('dap')._vim_exit_handler()")
 return M

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -200,7 +200,7 @@ function M.close()
   end
 
   if buf then
-    vim.cmd('bd' .. buf)
+    api.nvim_buf_delete(buf, {force = true})
     buf = nil
   end
 
@@ -242,12 +242,6 @@ function M.open(winopts, wincmd)
     vim.fn.prompt_setprompt(buf, 'dap> ')
     vim.fn.prompt_setcallback(buf, execute)
     api.nvim_buf_attach(buf, false, {
-      on_lines = function(b)
-        api.nvim_buf_set_option(b, 'modified', false)
-      end;
-      on_changedtick = function(b)
-        api.nvim_buf_set_option(b, 'modified', false)
-      end;
       on_detach = function()
         buf = nil
         return true


### PR DESCRIPTION
Should fix https://github.com/mfussenegger/nvim-dap/issues/119

If the repl is closed using `:bd` directly without force it will still fail if
the buffer is modified, but the `:qall`, `repl.close` and `repl.toggle` cases
work without error.