### PR TITLE
Remove the `dap` global

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -1,6 +1,3 @@
-dap = {} -- luacheck: ignore 111 - to support v:lua.dap... uses
-
-
 local uv = vim.loop
 local api = vim.api
 local log = require('dap.log').create_logger('dap.log')
@@ -1348,7 +1345,6 @@ function M.omnifunc(findstart, base)
   -- cancel but stay in completion mode for completion via `completions` callback
   return -2
 end
-dap.omnifunc = M.omnifunc  -- luacheck: ignore 112
 
 
 --- Attach to an existing debug-adapter running on host, port

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -230,7 +230,7 @@ function M.open(winopts, wincmd)
     api.nvim_buf_set_name(buf, '[dap-repl]')
     api.nvim_buf_set_option(buf, 'buftype', 'prompt')
     api.nvim_buf_set_option(buf, 'filetype', 'dap-repl')
-    api.nvim_buf_set_option(buf, 'omnifunc', 'v:lua.dap.omnifunc')
+    api.nvim_buf_set_option(buf, 'omnifunc', "v:lua.require'dap'.omnifunc")
     local ok, path = pcall(api.nvim_buf_get_option, prev_buf, 'path')
     if ok then
       api.nvim_buf_set_option(buf, 'path', path)


### PR DESCRIPTION
Neovim master supports `v:lua.require'dap'` which can be used instead
for the omnifunc.

Closes https://github.com/mfussenegger/nvim-dap/issues/115