### PR TITLE
Revert "Add some progress notifications when launching a session"

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -127,10 +127,8 @@ end
 
 local function run_adapter(adapter, configuration, opts)
   if adapter.type == 'executable' then
-    vim.notify('Running config: ' .. configuration.name)
     M.launch(adapter, configuration, opts)
   elseif adapter.type == 'server' then
-    vim.notify('Running config: ' .. configuration.name)
     M.attach(adapter.host, adapter.port, configuration, opts)
   else
     print(string.format('Invalid adapter type %s, expected `executable` or `server`', adapter.type))
@@ -200,10 +198,8 @@ function M.run(config, opts)
   config = vim.tbl_map(expand_config_variables, config)
   local adapter = M.adapters[config.type]
   if type(adapter) == 'table' then
-    vim.notify('Launching debug adapter')
     maybe_enrich_config_and_run(adapter, config, opts)
   elseif type(adapter) == 'function' then
-    vim.notify('Launching debug adapter')
     adapter(
       function(resolved_adapter)
         maybe_enrich_config_and_run(resolved_adapter, config, opts)


### PR DESCRIPTION
This reverts commit 0419f02339cb18912ae510f9dcf91ede6f2b28d6.

Caused an error if `name` was nil and if cmdheight is 1 instead of 2 the
notifications can trigger a ENTER prompt.

Will instead add a progress function that can be used for integration in
the statusline.