### PR TITLE
launch.json support extension

### DIFF
--- a/lua/dap/ext/vscode.lua
+++ b/lua/dap/ext/vscode.lua
@@ -22,7 +22,8 @@ function M.load_launchjs(path)
     local configurations = dap.configurations[config.type]
     if not configurations then
       configurations = {}
-      dap.configurations[config.type] = configurations
+      local config_key = config.nvimKey or config.type
+      dap.configurations[config_key] = configurations
     end
     table.insert(configurations, config)
   end

--- a/lua/dap/ext/vscode.lua
+++ b/lua/dap/ext/vscode.lua
@@ -19,10 +19,10 @@ function M.load_launchjs(path)
   assert(data.configurations, "launch.json must have a 'configurations' key")
   for _, config in ipairs(data.configurations) do
     assert(config.type, "Configuration in launch.json must have a 'type' key")
-    local configurations = dap.configurations[config.type]
+    local config_key = config.nvimKey or config.type
+    local configurations = dap.configurations[config_key]
     if not configurations then
       configurations = {}
-      local config_key = config.nvimKey or config.type
       dap.configurations[config_key] = configurations
     end
     table.insert(configurations, config)

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -732,9 +732,9 @@ end
 function Session:initialize(config)
   self.config = config
   self:request('initialize', {
-    clientId = 'neovim';
-    clientname = 'neovim';
-    adapterID = 'nvim-dap';
+    clientID = config.clientID or 'neovim';
+    clientName = config.clientName or 'neovim';
+    adapterID = config.type or 'nvim-dap';
     pathFormat = 'path';
     columnsStartAt1 = true;
     linesStartAt1 = true;


### PR DESCRIPTION
This is a draft PR as I wanted to get some suggestions as to if this even makes sense @mfussenegger 

* Add support for a non compliant ``nvimKey`` in debugger configurations for launch.json
The problem that arose for me was that many configurations used by default vscode have a type that is not the file extension expected by nvim-dap to be the key in the ``configurations`` table. 

* Make sure adapterID is set to the type instead of ``nvim-dap``. 
Some adapters actually check the adapter ID and fail when it's not the correct type. 

* Allow overriding clientID and clientName for a configuration definition. This allows for interesting scenarios such as simulating vscode-only debuggers