### PR TITLE
feat:  Add support for window split configuration

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -297,9 +297,24 @@ should be launched by nvim-dap:
 
 <
 
-`fallback` here can be replaced with the |dap-adapter| type to have type
-specific terminal configurations.
 
+If you're using the integrated terminal, you can also configure the command
+that is used to create a split window:
+
+
+>
+
+  lua << EOF
+  local dap = require('dap')
+  dap.defaults.fallback.terminal_win_cmd = '50vsplit new'
+  EOF
+<
+
+The `terminal_win_cmd` defaults to `belowright new`.
+
+
+`fallback` can be replaced with the |dap-adapter| type to have type
+specific terminal configurations.
 
 ==============================================================================
 API                                                  *dap-api*

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -37,6 +37,7 @@ M.defaults = setmetatable(
       exception_breakpoints = 'default';
       -- type SteppingGranularity = 'statement' | 'line' | 'instruction'
       stepping_granularity = 'statement';
+      terminal_win_cmd = 'belowright new';
     },
   },
   {

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -66,7 +66,8 @@ function Session:run_in_terminal(request)
   if terminal_buf and api.nvim_buf_is_valid(terminal_buf) then
     api.nvim_buf_delete(terminal_buf, {force=true})
   end
-  api.nvim_command('belowright new')
+  local termWinCmd = dap().defaults[self.config.type].terminal_win_cmd
+  api.nvim_command(termWinCmd)
   terminal_buf = api.nvim_get_current_buf()
   local opts = {
     clear_env = false;


### PR DESCRIPTION
Allow users to provide their own split command for opening a new window when using the integrated terminal.

A new property has been added to the configuration:  **windowSplit**.  If not provided, the default value of "belowright new" is used.

Example configurations:

### Open a new horizontal window below, with 20 height:
```
 require'dap'.configurations.python = {
    {
      type = 'python';
      request = 'launch';
      name = "Launch file";
      console = "integratedTerminal";
      windowSplit = 'botright 20new';
   }
}
```

### Open a new vertical window to the right, with 40 width:
```
 require'dap'.configurations.python = {
    {
      type = 'python'; 
      request = 'launch';
      name = "Launch file";
      console = "integratedTerminal";
      windowSplit = '40vsplit new';
   }
}
```
