### PR TITLE
Add opts argument to disconnect

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -377,11 +377,15 @@ stop()                                                              *dap.stop()*
         To disconnect the adapter as well, call |dap.disconnect()| before
         calling |dap.stop()|
 
-disconnect()                                                  *dap.disconnect()*
+disconnect(opts)                                              *dap.disconnect()*
         Disconnects the adapter from the current session. The session is not
         closed. To close the session, call |dap.stop()|.
  
         Requires an active session.
+
+        Parameters: ~
+            {opts}    Table with options for the disconnect request.
+                      Defaults to `{ restart = false, terminateDebuggee = true }`
 
 
 attach({host}, {port}, {config})                                 *dap.attach()*

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -437,10 +437,11 @@ end
 
 
 --- Disconnects an active session
-function M.disconnect()
+function M.disconnect(opts)
   if session then
-    -- Should result in a `terminated` event which closes the session and sets it to nil
-    session:disconnect()
+    session:disconnect(opts)
+    session:close()
+    session = nil
   else
     print('No active session. Doing nothing.')
   end

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -788,11 +788,12 @@ function Session:evaluate(expression, fn)
 end
 
 
-function Session:disconnect()
-  self:request('disconnect', {
+function Session:disconnect(opts)
+  opts = vim.tbl_extend('force', {
     restart = false,
     terminateDebuggee = true;
-  })
+  }, opts)
+  self:request('disconnect', opts)
 end
 
 


### PR DESCRIPTION
Allows to override the `restart` and `terminateDebuggee` arguments
