### PR TITLE
[WIP] Pass correct environment variables to termopen (integratedTerminal)

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -77,6 +77,22 @@ function Session:run_in_terminal(request)
     clear_env = false;
     env = non_empty(body.env) and body.env or vim.empty_dict()
   }
+
+  if vim.tbl_count(opts.env) > 0 then
+    local term_env = {}
+    for k, v in pairs(opts.env) do
+      if type(k) == 'string' and type(v) == 'string' then
+        term_env[k] = v
+      elseif type(v) == 'string' then
+        local sep = v:find("=")
+        if sep ~= nil then
+          term_env[v:sub(1, sep - 1)] = v:sub(sep + 1)
+        end
+      end
+    end
+    opts.env = term_env
+  end
+
   local jobid = vim.fn.termopen(body.args, opts)
   api.nvim_set_current_win(win)
   if jobid == 0 or jobid == -1 then


### PR DESCRIPTION
Fix #191 ([comment](https://github.com/mfussenegger/nvim-dap/issues/191#issuecomment-854442126))

I think nvim-dap should support only one type of env's in configuration, like this:

```lua
env = {
  ['PORT']  = '9001',
  ['GOOGLE_APPLICATION_CREDENTIALS'] = '${workspaceFolder}/.credentials/local.json'
}
```
And not:

```lua
env = {
  'PORT = 9001',
  'GOOGLE_APPLICATION_CREDENTIALS = "${workspaceFolder}/.credentials/local.json"'
}
```