### PR TITLE
Use vim.tbl_count() instead of non_empty

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -75,7 +75,7 @@ function Session:run_in_terminal(request)
   end
   local opts = {
     clear_env = false;
-    env = non_empty(body.env) and body.env or vim.empty_dict()
+    env = vim.tbl_count(body.env) > 0 and body.env or vim.empty_dict()
   }
   local jobid = vim.fn.termopen(body.args, opts)
   api.nvim_set_current_win(win)


### PR DESCRIPTION
"\#" lua operator return wrong result for dictionary like tables (with empty_dict metatable).
Also, `vim.tbl_count()` is better than `#`.
Fixes #191

```lua
-- https://github.com/neovim/neovim/blob/68d40388f356587726ea7db83f87846dfaecf9d9/runtime/doc/lua.txt#L650
-- Note: if numeric keys are added to the table, the metatable will be ignored and the dict converted to a list/array anyway.

local d

-- dictionary
d = vim.empty_dict()
print(vim.inspect(d))
d['k'] = 'v'
print(vim.inspect(d))
print('count #', #d) -- 0 element, what?
print('count vim.tbl_count()', vim.tbl_count(d)) -- 1 element

-- array
d = vim.empty_dict()
print(vim.inspect(d))
d[1] = 2
print(vim.inspect(d))
print('count #', #d) -- 1 element
print('count vim.tbl_count()', vim.tbl_count(d)) -- 1 element
```

As alternative, non_empty function can be:
```lua
function M.non_empty(object)
    if type(type) == "table" then
        return vim.tbl_count(object) > 0
    end

    return object and #object > 0
end