### PR TITLE
Improve rejected breakpoints feedback

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -215,12 +215,14 @@ call it once.
 SIGNS CONFIGURATION
 
 
-nvim-dap uses three signs:
+nvim-dap uses four signs:
 
 - `DapBreakpoint` which defaults to `B` for breakpoints
 - `DapLogPoint` which defaults to `L` and is for log-points
 - `DapStopped` which defaults to `→` and is used to indicate the position where
   the debugee is stopped.
+- `DapBreakpointRejected`, defaults to `R` for breakpoints which the debug
+  adapter rejected.
 
 You can customize the signs by overriding the definition after you've loaded `dap`.
 An example:

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -117,6 +117,7 @@ M.configurations = {}
 
 
 vim.fn.sign_define('DapBreakpoint', {text='B', texthl='', linehl='', numhl=''})
+vim.fn.sign_define('DapBreakpointRejected', {text='R', texthl='', linehl='', numhl=''})
 vim.fn.sign_define('DapLogPoint', {text='L', texthl='', linehl='', numhl=''})
 vim.fn.sign_define('DapStopped', {text='→', texthl='', linehl='debugPC', numhl=''})
 

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -414,9 +414,12 @@ do
           print("Error setting breakpoints: " .. err1.message)
         else
           for _, bp in pairs(resp.breakpoints) do
+            breakpoints.set_state(bufnr, bp.line, bp)
             if not bp.verified then
               log.info('Server rejected breakpoint', bp)
-              breakpoints.remove(bufnr, bp.line)
+              if bp.message then
+                vim.notify(bp.message)
+              end
             end
           end
         end


### PR DESCRIPTION
- The breakpoints are now kept, but the sign is updated
- If the server response contains a message, it is printed
- The quickfix list shows the rejected message if available
