### PR TITLE
Add an option to force external terminal

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -280,8 +280,9 @@ Some debug adapters support launching the debugee in an integrated terminal or
 an external terminal.
 
 For that they usually provide a `console` option in their |dap-configuration|.
-The supported values are usually called `internalConsole`, `integratedTerminal`
-and `externalTerminal`.
+The supported values are sometimes called `internalConsole`,
+`integratedTerminal` and `externalTerminal`, but you need to consult the debug
+adapter documentation to figure out the concrete property name and values.
 
 
 If you want to use the `externalTerminal` you need to setup the terminal which
@@ -299,8 +300,22 @@ should be launched by nvim-dap:
 
 <
 
+Some debug adapters support launching the debugee in a terminal, but don't
+provide an option to choose between integrated terminal or external terminal.
+`nvim-dap` provides an option to force the external terminal.
 
-If you're using the integrated terminal, you can also configure the command
+
+>
+
+  lua << EOF
+  local dap = require('dap')
+  dap.defaults.fallback.force_external_terminal = true
+  EOF
+
+<
+
+
+If you're using the integrated terminal, you can configure the command
 that is used to create a split window:
 
 

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -46,8 +46,9 @@ end
 function Session:run_in_terminal(request)
   local body = request.arguments
   log.debug('run_in_terminal', body)
-  if body.kind == 'external' then
-    local terminal = dap().defaults[self.config.type].external_terminal
+  local settings = dap().defaults[self.config.type]
+  if body.kind == 'external' or (settings.force_external_terminal and settings.external_terminal) then
+    local terminal = settings.external_terminal
     if not terminal then
       print('Requested external terminal, but none configured. Fallback to integratedTerminal')
     else


### PR DESCRIPTION
This can be useful for lldb-vscode where you can set `runInTerminal =
true` but don't have an option to choose between integrated and external
terminal.



https://user-images.githubusercontent.com/38700/121802503-ee1e4f80-cc3c-11eb-9616-e2e9b4aa52ee.mp4

