### PR TITLE
Add more predefined variables

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -189,10 +189,15 @@ Things to note:
   they will be evaluated once the configuration is used.
 
 - Some variables are supported:
-
   - `${file}`: Active filename
+  - `${fileBasename}`: The current file's basename
+  - `${fileBasenameNoExtension}`: The current file's basename without extension
+  - `${fileDirname}`: The current file's dirname
+  - `${fileExtname}`: The current file's extension
+  - `${relativeFile}`: The current file relative to |getcwd()|
+  - `${relativeFileDirname}`: The current file's dirname relative to |getcwd()|
   - `${workspaceFolder}`: The current working directory of Neovim
-
+  - `${workspaceFolderBasename}`: The name of the folder opened in Neovim
 
 ==============================================================================
 DEBUGEE CONFIGURATION via launch.json                *dap-launch.json*

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -96,7 +96,18 @@ M.adapters = {}
 --    request = 'launch';
 --    name = "Launch file";
 --
---    -- ${file} and ${workspaceFolder} variables are supported
+--    -- Some predefined variables are supported. Their definitions can be found here
+--    -- https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables-examples
+--    -- The supported variables are:
+--    -- ${file}
+--    -- ${fileBasename}
+--    -- ${fileBasenameNoExtension}
+--    -- ${fileDirname}
+--    -- ${fileExtname}
+--    -- ${relativeFile}
+--    -- ${relativeFileDirname}
+--    -- ${workspaceFolder}
+--    -- ${workspaceFolderBasename}
 --    program = "${file}";
 --
 --    -- values other than type, request and name can be functions, they'll be evaluated when the configuration is used
@@ -134,7 +145,14 @@ local function expand_config_variables(option)
   end
   local variables = {
     file = vim.fn.expand("%");
+    fileBasename = vim.fn.expand("%:t");
+    fileBasenameNoExtension = vim.fn.fnamemodify(vim.fn.expand("%:t"), ":r");
+    fileDirname = vim.fn.expand("%:p:h");
+    fileExtname = vim.fn.expand("%:e");
+    relativeFile = vim.fn.expand("%");
+    relativeFileDirname = vim.fn.fnamemodify(vim.fn.expand("%:h"), ":r");
     workspaceFolder = vim.fn.getcwd();
+    workspaceFolderBasename = vim.fn.fnamemodify(vim.fn.getcwd(), ":t");
   }
   local ret = option
   for key, val in pairs(variables) do


### PR DESCRIPTION
### Summary
This PR adds more predefined variables like `${file}` and `${workspaceFolder}` which should match VS Code examples defined [here](https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables-examples).

### Motivation
I was trying to create a Go Delve configuration that used `${fileDirname}` based off these [docs](https://go.googlesource.com/vscode-go/+/HEAD/docs/debugging.md#debug-a-single-test-function). I don't know if you have any interest in supporting all of these but they were simple enough to construct so I figured I'd include as many as I could.

With this variable I can now construct a config that looks like this to debug all tests within a package:
``` lua
    {
      type = "go",
      name = "Debug package tests", -- configuration for debugging test files
      request = "launch",
      mode = "test",
      program = "${fileDirname}/...",
    },

```

Also, it looks like `${file}` in this repo is relative to the workspace but `${file}` in VS Code is absolute. I don't know if that was intentional or not, just an FYI. Thanks for taking the time to review :smile: 