### PR TITLE
Remove variables API docs

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -667,48 +667,6 @@ status()
         If no debug session is active the result is empty.
 
 ==============================================================================
-VARIABLES API                                           *dap-ui-variables-api*
-
-Lua module: dap.ui.variables
-
-
-The methods listed here are in the `dap.ui.variables` module. To use them you have to import the module:
-
->
-
-    local variables_ui = require('dap.ui.variables')
-
-<
-
-
-hover()                                               *dap.ui.variables.hover()*
-        Opens a floating window with information about the variable under the
-        cursor.
-
-        Requires an active debug session.
-
-scopes()                                            *dap.ui.variables.scopes()*
-        Opens a hover with all variable scopes of the current frame.
-
-        Requires an active debug session.
-
-visual_hover()                                 *dap.ui.variables.visual_hover()*
-        Opens a floating window with information on the value of the 
-        current visual selection.
-
-        Requires an active debug session.
-
-toggle_multiline_display({value})  *dap.ui.variables.toggle_multiline_display()*
-        Toggles between single and multi-line variable display in the variable
-        hover window or sets multi-line display on or off when `{values}` is
-        provided.
-
-        This functionality is also available by pressing "g?" in normal mode
-        in a hover window.
-
-
-
-==============================================================================
 WIDGET API                                                    *dap-widgets*
 
 


### PR DESCRIPTION
The widget API should be used instead.
With the exception of the multiline toggle there should be feature
parity between the two.
