### PR TITLE
Keep repl.append content if repl is hidden

### DIFF
--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -266,21 +266,17 @@ end
 
 
 function M.append(line, lnum)
-  if repl.buf then
-    if api.nvim_get_current_win() == repl.win and lnum == '$' then
-      lnum = nil
-    end
-    if api.nvim_buf_get_option(repl.buf, 'fileformat') ~= 'dos' then
-      line = line:gsub('\r\n', '\n')
-    end
-    local lines = vim.split(line, '\n')
-    api.nvim_buf_call(repl.buf, function()
-      lnum = lnum or (vim.fn.line('$') - 1)
-      vim.fn.appendbufline(repl.buf, lnum, lines)
-    end)
-    return lnum
+  local buf = repl._init_buf()
+  if api.nvim_get_current_win() == repl.win and lnum == '$' then
+    lnum = nil
   end
-  return nil
+  if api.nvim_buf_get_option(buf, 'fileformat') ~= 'dos' then
+    line = line:gsub('\r\n', '\n')
+  end
+  local lines = vim.split(line, '\n')
+  lnum = lnum or api.nvim_buf_line_count(buf) - 1
+  vim.fn.appendbufline(buf, lnum, lines)
+  return lnum
 end
 
 


### PR DESCRIPTION
During debugging (or when running junit tests with extensions like
nvim-jdtls) output may be written to the REPL. Previously this output
was discarded if the REPL wasn't open.

This commit changes the behavior to preserve the output until the next
debug session starts - or until the REPL was opened and is then closed
again.
