### PR TITLE
Allow to override the active session

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -672,13 +672,15 @@ function M._vim_exit_handler()
   M.repl.close()
 end
 
-function M._reset_session()
-  session = nil
-end
 
 --- Return the current session or nil
 function M.session()
   return session
+end
+
+
+function M.set_session(s)
+  session = s
 end
 
 

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -328,7 +328,7 @@ function Session:event_terminated()
   if self.handlers.after then
     self.handlers.after()
   end
-  dap()._reset_session()
+  dap().set_session(nil)
 end
 
 
@@ -791,10 +791,10 @@ function Session:initialize(config)
       if err then
         print(string.format('Error on %s: %s', config.request, err.message))
         self:close()
-        dap()._reset_session()
-        return
+        dap().set_session(nil)
+      else
+        require('dap.repl').set_session(self)
       end
-      require('dap.repl').set_session(self)
     end)
   end)
 end


### PR DESCRIPTION
This adds a (as of now undocumented) `set_session` method that allows
extensions to change the active session with which the user facing
commands are interacting.

This is useful for extensions like nvim-dap-python because debug
adapters like debugpy contain custom extensions to the core debug
adapter protocol where they need to have multiple sessions running at
the same time.

Until multi-sessions become part of the official specification,
multi-session support is out-of-scope for nvim-dap, but this method
should be enough to allow extensions to do the remaining work.

(The UX may not be ideal because breakpoints are global and there exists
no breakpoint - session mapping, but it should at least make it possible
to get things working in some way)
