### PR TITLE
Use cwd from runInTerminal request for termopen call

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -89,7 +89,8 @@ function Session:run_in_terminal(request)
   end
   local opts = {
     clear_env = false;
-    env = next(body.env or {}) and body.env or vim.empty_dict()
+    env = next(body.env or {}) and body.env or vim.empty_dict(),
+    cwd = (body.cwd and body.cwd ~= '') and body.cwd or nil
   }
   local jobid = vim.fn.termopen(body.args, opts)
   api.nvim_set_current_win(cur_win)


### PR DESCRIPTION
Should fix https://github.com/mfussenegger/nvim-dap/issues/228
