### PR TITLE
Allow null values as argument to to_dict

### DIFF
--- a/lua/dap/utils.lua
+++ b/lua/dap/utils.lua
@@ -8,7 +8,7 @@ local M = {}
 function M.to_dict(values, get_key, get_value)
   local rtn = {}
   get_value = get_value or function(v) return v end
-  for _, v in pairs(values) do
+  for _, v in pairs(values or {}) do
     rtn[get_key(v)] = get_value(v)
   end
   return rtn

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -22,4 +22,9 @@ describe('utils.to_dict', function()
     }
     assert.are.same(expected, result)
   end)
+
+  it('supports nil values as argument', function()
+    local result = require('dap.utils').to_dict(nil, function(x) return x end)
+    assert.are.same(result, {})
+  end)
 end)


### PR DESCRIPTION
Workaround for https://github.com/mfussenegger/nvim-dap/issues/225
