### PR TITLE
Prevent view.toggle from deleting a buffer

### DIFF
--- a/lua/dap/ui.lua
+++ b/lua/dap/ui.lua
@@ -260,7 +260,8 @@ function M.new_view(new_buf, new_win, opts)
         self.win = nil
         closed = true
       end
-      if buf and (closed or close_opts.mode ~= 'toggle') then
+      local hide = close_opts.mode == 'toggle'
+      if buf and not hide then
         pcall(api.nvim_buf_delete, buf, {force=true})
         self.buf = nil
       end


### PR DESCRIPTION
This will allow `view.toggle()` to be used for terminal buffers without
interrupting the execution.
