### PR TITLE
Revert "repl lines issue use vim.trim()"

### DIFF
--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -273,7 +273,10 @@ function M.append(line, lnum)
   if api.nvim_buf_get_option(buf, 'fileformat') ~= 'dos' then
     line = line:gsub('\r\n', '\n')
   end
-  local lines = vim.split(vim.trim(line), '\n')
+  local lines = vim.split(line, '\n')
+  if #lines > 1 and lines[#lines] == '' then
+    table.remove(lines)
+  end
   lnum = lnum or api.nvim_buf_line_count(buf) - 1
   vim.fn.appendbufline(buf, lnum, lines)
   return lnum


### PR DESCRIPTION
This reverts commit 12f208b4a6463c69d9140e1a6ce5806a552330f2.

`vim.trim()` also removes leading whitespace, which is not always what a
user may want.

For example, nvim-jdtls outputs stacktraces on the REPL.

With vim.trim(), this looks like follows:

    ❌testExecutionPhaseIdSequence
    java.lang.AssertionError:
    Expected: is <3>
    but: was <0>
    at __randomizedtesting.SeedInfo.seed([6ECD24DB888A0803:2DF3FE03A2B7ACE5]:0)
    at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
    at org.junit.Assert.assertThat(Assert.java:964)
    at org.junit.Assert.assertThat(Assert.java:930)

Reverting this change restores the previous behavior:

    ❌testExecutionPhaseIdSequence
    java.lang.AssertionError:
    Expected: is <3>
         but: was <0>
    	at __randomizedtesting.SeedInfo.seed([C3CE5B0CBD15A42:4F023F68E1ECFEA4]:0)
    	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
    	at org.junit.Assert.assertThat(Assert.java:964)
    	at org.junit.Assert.assertThat(Assert.java:930)
