### PR TITLE
fix(ui): handle empty text in repl

### DIFF
--- a/lua/dap/ui.lua
+++ b/lua/dap/ui.lua
@@ -404,6 +404,11 @@ function M.layer(buf)
               buf, nshl, hl_region[1], i, hl_region[2], hl_region[3])
           end
         end
+
+        if #text == 0 then
+          return
+        end
+
         local mark_id = api.nvim_buf_set_extmark(buf, ns, i, 0, {end_col=(#text - 1)})
         marks[mark_id] = { mark_id = mark_id, item = item, context = context }
       end


### PR DESCRIPTION
There's an error raised if a REPL command returns no text. For example assigning a variable in python.

```
Error executing vim.schedule lua callback: ...ache/nvim/site/pack/packer/start/nvim-dap/lua/dap/ui.lua:407: end_col value outside rang
```
This is more of a quick fix suggestion that I found while testing, not sure if this how you would want to handle this