### PR TITLE
unwrap text with variable description too long

### DIFF
--- a/lua/dap/ui/variables.lua
+++ b/lua/dap/ui/variables.lua
@@ -221,6 +221,7 @@ local function popup()
   -- width and height are increased later once variables are written to the buffer
   local opts = vim.lsp.util.make_floating_popup_options(1, 1, {})
   local win = api.nvim_open_win(buf, true, opts)
+  api.nvim_win_set_option(win, "wrap", false)
   return win, buf
 end
 


### PR DESCRIPTION
before:
![before](https://user-images.githubusercontent.com/70128797/126897419-384204ad-3699-4aa3-bfc6-15e8890b6ed2.gif)

after:
![after](https://user-images.githubusercontent.com/70128797/126897527-302b9fd6-36fe-4f04-aacc-623d6269815b.gif)
