### PR TITLE
Rename dap.stop() to dap.close() and clarify docs

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -3,4 +3,7 @@ ignore = {
 }
 read_globals = {
   "vim",
+  "describe",
+  "it",
+  "assert"
 }

--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -394,20 +394,27 @@ launch({adapter}, {config})                                       *dap.launch()*
                         not required in this case.
             {config}    |dap-configuration|
 
-stop()                                                              *dap.stop()*
+close()                                                            *dap.close()*
         Closes the current session.
+
+        This is NOT guaranteed to terminate the debug adapter or debugee.
         To disconnect the adapter as well, call |dap.disconnect()| before
-        calling |dap.stop()|
+        calling |dap.close()|
+
 
 disconnect(opts)                                              *dap.disconnect()*
-        Disconnects the adapter from the current session. The session is not
-        closed. To close the session, call |dap.stop()|.
- 
+
+        disconnect asks the debug adapter to disconnect from the debuggee and
+        to terminate the debug adapter.
+
+        The client session may remain open if the debug adapter does not
+        terminate. To ensure the session gets closed, also call |dap.close()|.
+
         Requires an active session.
 
         Parameters: ~
             {opts}    Table with options for the disconnect request.
-                      Defaults to `{ restart = false, terminateDebuggee = true }`
+                      Defaults to `{ restart = false, terminateDebuggee = null }`
 
 
 attach({host}, {port}, {config})                                 *dap.attach()*

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -343,6 +343,12 @@ end
 
 
 function M.stop()
+  vim.notify('dap.stop() is deprecated. Call dap.close() instead')
+  M.close()
+end
+
+
+function M.close()
   if session then
     session:close()
     session = nil
@@ -496,8 +502,8 @@ function M.continue()
     )
     local choices = {
       {
-        label = "Stop session",
-        action = M.stop
+        label = "Close session (Debug adapter might keep running)",
+        action = M.close
       },
       {
         label = "Pause a thread",
@@ -509,7 +515,9 @@ function M.continue()
       },
       {
         label = "Disconnect (terminate = true)",
-        action = M.disconnect,
+        action = function()
+          M.disconnect({ terminateDebuggee = true })
+        end
       },
       {
         label = "Disconnect (terminate = false)",

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -810,7 +810,7 @@ end
 function Session:disconnect(opts)
   opts = vim.tbl_extend('force', {
     restart = false,
-    terminateDebuggee = true;
+    terminateDebuggee = nil;
   }, opts or {})
   self:request('disconnect', opts)
 end

--- a/tests/integration_spec.lua
+++ b/tests/integration_spec.lua
@@ -8,7 +8,7 @@ describe('dap', function()
   os.execute('python -m venv "' .. venv_dir .. '"')
   os.execute(venv_dir .. '/bin/python -m pip install debugpy')
   after_each(function()
-    dap.stop()
+    dap.close()
   end)
 
   it('Basic debugging flow', function()


### PR DESCRIPTION
dap.stop() is still kept, but will emit a message that it is
deprecated.

This also changes the default for `terminateDebuggee` in `disconnect` to
`nil` - which means the behavior is up to the debug adapter.
