### PR TITLE
Use layer.render to clear REPL to remove extmarks

### DIFF
--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -294,7 +294,8 @@ function M.clear()
   history.entries = {}
   history.idx = 1
   if repl.buf and api.nvim_buf_is_loaded(repl.buf) then
-    api.nvim_buf_set_lines(repl.buf, 0, -1, true, {})
+    local layer = ui.layer(repl.buf)
+    layer.render({}, tostring, {}, 0, - 1)
   end
 end
 


### PR DESCRIPTION
Fixes https://github.com/mfussenegger/nvim-dap/issues/237
