### PR TITLE
Add set-expression/set-variable widget actions

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -742,6 +742,12 @@ View the value for the expression under the cursor in a floating window:
 <
 
 
+The widgets may have the following custom mappings enabled:
+
+- `<CR>` to expand or collapse an entry
+- `a` to show a menu with available actions
+
+
 Available widgets entities:
 
 - scopes

--- a/lua/dap/entity.lua
+++ b/lua/dap/entity.lua
@@ -158,8 +158,11 @@ variable.tree_spec = {
   get_children = variable.get_children,
   fetch_children = variable.fetch_children,
   compute_actions = function(info)
-    local result = {}
     local session = require('dap').session()
+    if not session then
+      return {}
+    end
+    local result = {}
     local capabilities = session.capabilities
     local item = info.item
     if item.evaluateName and capabilities.supportsSetExpression then

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -27,7 +27,7 @@ local function new_buf()
   if ok then
     api.nvim_buf_set_option(buf, 'path', path)
   end
-  api.nvim_buf_set_keymap(buf, 'n', '<CR>', "<Cmd>lua require('dap.repl').on_enter()<CR>", {})
+  api.nvim_buf_set_keymap(buf, 'n', '<CR>', "<Cmd>lua require('dap.ui').trigger_actions({ filter = 'Expand' })<CR>", {})
   api.nvim_buf_set_keymap(buf, 'i', '<up>', "<Cmd>lua require('dap.repl').on_up()<CR>", {})
   api.nvim_buf_set_keymap(buf, 'i', '<down>', "<Cmd>lua require('dap.repl').on_down()<CR>", {})
   vim.fn.prompt_setprompt(buf, 'dap> ')
@@ -242,8 +242,6 @@ M.open = repl.open
 
 --- Open the REPL if it is closed, close it if it is open.
 M.toggle = repl.toggle
-
-M.on_enter = ui.trigger_actions
 
 
 local function select_history(delta)

--- a/lua/dap/ui/widgets.lua
+++ b/lua/dap/ui/widgets.lua
@@ -6,10 +6,13 @@ local M = {}
 
 local function new_buf()
   local buf = api.nvim_create_buf(false, true)
+  api.nvim_buf_set_option(buf, 'modifiable', false)
   api.nvim_buf_set_option(buf, 'buftype', 'nofile')
   api.nvim_buf_set_option(buf, 'modifiable', false)
   api.nvim_buf_set_keymap(
-    buf, "n", "<CR>", "<Cmd>lua require('dap.ui').trigger_actions()<CR>", {})
+    buf, "n", "<CR>", "<Cmd>lua require('dap.ui').trigger_actions({ filter = 'Expand' })<CR>", {})
+  api.nvim_buf_set_keymap(
+    buf, "n", "a", "<Cmd>lua require('dap.ui').trigger_actions()<CR>", {})
   api.nvim_buf_set_keymap(
     buf, "n", "<2-LeftMouse>", "<Cmd>lua require('dap.ui').trigger_actions()<CR>", {})
   return buf

--- a/lua/dap/ui/widgets.lua
+++ b/lua/dap/ui/widgets.lua
@@ -130,7 +130,9 @@ M.scopes = {
     local frame = session and session.current_frame or {}
     local tree = view.tree
     if not tree then
-      tree = ui.new_tree(require('dap.entity').scope.tree_spec)
+      local spec = vim.deepcopy(require('dap.entity').scope.tree_spec)
+      spec.extra_context = { view = view }
+      tree = ui.new_tree(spec)
       view.tree = tree
     end
     local layer = view.layer()


### PR DESCRIPTION
Mostly to introduce the concept of having multiple actions per item in a widget.

Doesn't add too much meaningful functionality - the debug adapters I tested with struggle with `setVariable` and `setExpression`. Using `evaluate` via the REPL is easier and works better.

Data breakpoints might be a candidate for adding next