### PR TITLE
Ensure repl.clear is run in main loop

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -772,7 +772,7 @@ end
 
 
 function Session:initialize(config, adapter)
-  require('dap.repl').clear()
+  vim.schedule(require('dap.repl').clear)
   adapter = adapter or {}
   local adapter_responded = false
   self.config = config


### PR DESCRIPTION
Since 11291a4a01fa43e8b1b51d522c7cd7788147056f Session:initialize can be
called in the luv event-loop, and repl.clear must run in the main loop
