### PR TITLE
Clarify how to use dap.repl custom_commands

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -610,29 +610,21 @@ repl.open({winopts}, {wincmd})                                 *dap.repl.open()*
           .rc or
           .reverse-continue   Same as |dap.reverse_continue|
 
-        You can customize the commands by overriding `dap.repl.commands`:
+        You can customize the builtin command names or define your own
+        custom commands by extending `dap.repl.commands`:
         >
-          dap.repl.commands = vim.tbl_extend('force', dap.repl.commands, {
-            continue = {'.continue', '.c'},
-            next_ = {'.next', '.n'},
-            back = {'.back', '.b'},
-            reverse_continue = {'.reverse-continue', '.rc'},
-            into = {'.into'},
-            into_target = {'.into_target'},
-            out = {'.out'},
-            scopes = {'.scopes'},
-            threads = {'.threads'},
-            frames = {'.frames'},
-            exit = {'exit', '.exit'},
-            up = {'.up'},
-            down = {'.down'},
-            goto_ = {'.goto'},
-            capabilities = {'.capabilities'},
-            -- add your own commands
+          local repl = require 'dap.repl'
+          repl.commands = vim.tbl_extend('force', repl.commands, {
+            -- Add a new alias for the existing .exit command
+            exit = {'exit', '.exit', '.bye'},
+            -- Add your own commands; run `.echo hello world` to invoke
+            -- this function with the text "hello world"
             custom_commands = {
               ['.echo'] = function(text)
                 dap.repl.append(text)
-              end
+              end,
+              -- Hook up a new command to an existing dap function
+              ['.restart'] = dap.restart,
             },
           }
 

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -210,8 +210,9 @@ function execute(text)
   elseif vim.tbl_contains(M.commands.frames, text) then
     M.print_stackframes()
   elseif M.commands.custom_commands[splitted_text[1]] then
-    local command = table.remove(splitted_text, 1)
-    M.commands.custom_commands[command](text)
+    local command = splitted_text[1]
+    local args = string.sub(text, string.len(command)+2)
+    M.commands.custom_commands[command](args)
   else
     session:evaluate(text, evaluate_handler)
   end


### PR DESCRIPTION
1. Make it clear in the example that one must require "dap.repl" before
   extending the dap.repl.commands table; otherwise the lazy-loaded repl
   won't see the custom commands in the extended table, even though the
   changes are visible to vim.inspect().

2. Also make it clear what you can or cannot hope to do by extending the
   commands table: you can add aliases for existing builtin commands
   (but not override them), you can hook up a new command to an existing
   dap function, or define an entirely new custom command as a function
   (and you only need to override what you want to change).

3. Earlier, the code would invoke the custom command with the whole of
   the command text, i.e., ".echo hello world". On the basis that it's
   inconvenient for every custom command to have to always strip the
   command name from its arguments, we now pass only "hello world".

   This change has the potential to break existing custom commands that
   expect the command name to be included in the function argument, but
   a Github code search found no custom_commands other than the '.echo'
   example copied from the docs, or commands that didn't take arguments.