### PR TITLE
Avoid repl lazy loading to avoid crash on latest master

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -6,6 +6,7 @@ local utils = require('dap.utils')
 local breakpoints = require('dap.breakpoints')
 local progress = require('dap.progress')
 local log = require('dap.log').create_logger('dap.log')
+local repl = require('dap.repl')
 local non_empty = utils.non_empty
 local index_of = utils.index_of
 
@@ -153,7 +154,6 @@ function Session:_show_exception_info()
     if response then
       local exception_type = response.details and response.details.typeName
       local of_type = exception_type and ' of type '..exception_type or ''
-      local repl = require('dap.repl')
       repl.append('Thread stopped due to exception'..of_type..' ('..response.breakMode..')')
       if response.description then
         repl.append('Description: '..response.description)
@@ -336,7 +336,6 @@ function Session.event_output(_, body)
   if body.category == 'telemetry' then
     log.info('Telemetry', body.output)
   else
-    local repl = require('dap.repl')
     repl.append(body.output, '$')
   end
 end
@@ -781,7 +780,7 @@ end
 
 
 function Session:initialize(config, adapter)
-  vim.schedule(require('dap.repl').clear)
+  vim.schedule(repl.clear)
   adapter = adapter or {}
   local adapter_responded = false
   self.config = config


### PR DESCRIPTION
There's currently an issue on neovim master that causes loading
(uncached) modules within a luv callback to crash neovim.

This moves the `require(dap.repl)` call to the top of the session - the
session itself is already lazy loaded and it should be fine to pull in
all dependencies in that case.
