### PR TITLE
Double the default timeout period for session.

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -826,7 +826,7 @@ function Session:initialize(config, adapter)
   end)
   local sec_to_ms = 1000
   local timer = vim.loop.new_timer()
-  timer:start(2 * sec_to_ms, 0, function()
+  timer:start(4 * sec_to_ms, 0, function()
     timer:stop()
     timer:close()
     if not adapter_responded then


### PR DESCRIPTION
Following up on the convo in
https://github.com/mfussenegger/nvim-dap/discussions/314#discussioncomment-1381937
I figured I'd quickly just bump this from 2 -> 4. It might be just
bumping this a bit like this gets rid of the need to even have this
configurable.