### PR TITLE
Fix scope widget refresh

### DIFF
--- a/lua/dap/ui.lua
+++ b/lua/dap/ui.lua
@@ -220,7 +220,7 @@ function M.new_tree(opts)
       end
     end,
 
-    render = function(layer, value)
+    render = function(layer, value, on_done)
       layer.render({value}, opts.render_parent)
       if not opts.has_children(value) then
         return
@@ -230,6 +230,9 @@ function M.new_tree(opts)
       end
       eager_fetch_expanded_children(value, function()
         render_all_expanded(layer, value)
+        if on_done then
+          on_done()
+        end
       end)
     end,
   }

--- a/lua/dap/ui/widgets.lua
+++ b/lua/dap/ui/widgets.lua
@@ -133,9 +133,17 @@ M.scopes = {
       view.tree = tree
     end
     local layer = view.layer()
-    for _, scope in pairs(frame.scopes or {}) do
-      tree.render(layer, scope)
+    local scopes = frame.scopes or {}
+    local render
+    render = function(idx, scope)
+      if not scope then
+        return
+      end
+      tree.render(layer, scope, function()
+        render(next(scopes, idx))
+      end)
     end
+    render(next(scopes))
   end,
 }
 


### PR DESCRIPTION
`render_all_expanded` is called asynchronously, which could mix up the
rendering of variables between different scopes.

This changes the loop over the scopes to render one scope after another.

This should fix https://github.com/mfussenegger/nvim-dap/issues/322
