### PR TITLE
Add clear_all_breakpoints function

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -440,6 +440,9 @@ function M.toggle_breakpoint(condition, hit_condition, log_message, replace_old)
   end
 end
 
+function M.clear_all_breakpoints()
+  lazy.breakpoints.clear();
+end
 
 -- setExceptionBreakpoints (https://microsoft.github.io/debug-adapter-protocol/specification#Requests_SetExceptionBreakpoints)
 --- filters: string[]


### PR DESCRIPTION
When I end a debugging session, all of the breakpoints I used are still there and have to be removed one by one. I thought it might be a good idea to add `clear_all_breakpoints` functionality.
I can also create the documentation and add it to this PR, if this idea gets approved.

If you don't like it, feel free to cancel this PR, I will just create a script that does this for me.

(This is also my first open-source PR, I'm sorry if I'm doing anything wrong.)