### PR TITLE
Add deprecation warnings to ui.variables functions

### DIFF
--- a/lua/dap/ui/variables.lua
+++ b/lua/dap/ui/variables.lua
@@ -250,6 +250,7 @@ end
 
 
 function M.scopes()
+  vim.notify('dap.ui.variables.scopes is deprecated, please use the widget API (:h dap-widgets)', vim.log.levels.WARN)
   if not is_stopped_at_frame() then return end
 
   local session = require('dap').session()
@@ -260,6 +261,7 @@ end
 
 
 function M.hover(resolve_expression_fn)
+  vim.notify('dap.ui.variables.hover is deprecated, please use the widget API (:h dap-widgets)', vim.log.levels.WARN)
   if not is_stopped_at_frame() then return end
 
   local session = require('dap').session()


### PR DESCRIPTION
The docs got already removed quite some time ago.
This adds a warning and in a couple weeks I'll remove the module.
