### PR TITLE
Ensure ${file} maps to absolute path and {$relativeFile} to relative path

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -144,12 +144,12 @@ local function expand_config_variables(option)
     return option
   end
   local variables = {
-    file = vim.fn.expand("%");
+    file = vim.fn.expand("%:p");
     fileBasename = vim.fn.expand("%:t");
     fileBasenameNoExtension = vim.fn.fnamemodify(vim.fn.expand("%:t"), ":r");
     fileDirname = vim.fn.expand("%:p:h");
     fileExtname = vim.fn.expand("%:e");
-    relativeFile = vim.fn.expand("%");
+    relativeFile = vim.fn.expand("%:.");
     relativeFileDirname = vim.fn.fnamemodify(vim.fn.expand("%:h"), ":r");
     workspaceFolder = vim.fn.getcwd();
     workspaceFolderBasename = vim.fn.fnamemodify(vim.fn.getcwd(), ":t");


### PR DESCRIPTION
Both breaking change and bugfix, see
https://github.com/mfussenegger/nvim-dap/issues/351 for context.

Without this change, the value of `${file}` depends on how you open a
file. `:e myFile` will resolve to `myFile` and `:e /path/to/myFile`
resolves to `/path/to/myFile`.

After this change `${file}` will always return the absolute path,
independent of how you open a file.

Side effect of this is that it breaks usages of
`${workspaceFolder}/${file}`.
