### PR TITLE
Add remap for backspace in repl

### DIFF
--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -285,6 +285,10 @@ function M.prompt_backspace()
   local currentLine = vim.api.nvim_buf_get_lines(0, currentLineNumber-1, currentLineNumber, false)[1]
   local _, endPromptPrefix = string.find(currentLine, "> ")
 
+  if endPromptPrefix == nil then
+    endPromptPrefix = 0
+  end
+
   if (currentColumnNumber-1) ~= endPromptPrefix then
     vim.api.nvim_buf_set_text(0, currentLineNumber-1, currentColumnNumber-2, currentLineNumber-1, currentColumnNumber-1, {""})
     vim.api.nvim_win_set_cursor(0, {currentLineNumber, currentColumnNumber-2})

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -279,14 +279,14 @@ function M.prompt_backspace()
   -- Note 1: Insert mode cursor is after (+1) the column as opposed to in normal mode it would be on (+0) the column.
   -- Note 2: nvim_win_[get|set]_cursor is (1, 0) indexed for (line, column) while nvim_buf_[get|set]_[lines|text] is 0 indexed for both.
 
-  local currentCursor = vim.api.nvim_win_get_cursor(0)
-  local currentLineNumber = currentCursor[1]
-  local currentColumnNumber = currentCursor[2]
-  local promptLength = string.len(vim.fn['prompt_getprompt']('%'));
+  local current_cursor = vim.api.nvim_win_get_cursor(0)
+  local current_line_number = current_cursor[1]
+  local current_column_number = current_cursor[2]
+  local prompt_length = string.len(vim.fn['prompt_getprompt']('%'));
 
-  if (currentColumnNumber) ~= promptLength then
-    vim.api.nvim_buf_set_text(0, currentLineNumber-1, currentColumnNumber-1, currentLineNumber-1, currentColumnNumber, {""})
-    vim.api.nvim_win_set_cursor(0, {currentLineNumber, currentColumnNumber-1})
+  if (current_column_number) ~= prompt_length then
+    vim.api.nvim_buf_set_text(0, current_line_number-1, current_column_number-1, current_line_number-1, current_column_number, {""})
+    vim.api.nvim_win_set_cursor(0, {current_line_number, current_column_number-1})
   end
 end
 

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -282,7 +282,7 @@ function M.prompt_backspace()
   local current_cursor = vim.api.nvim_win_get_cursor(0)
   local current_line_number = current_cursor[1]
   local current_column_number = current_cursor[2]
-  local prompt_length = string.len(vim.fn['prompt_getprompt']('%'));
+  local prompt_length = vim.str_utfindex(vim.fn['prompt_getprompt']('%'));
 
   if (current_column_number) ~= prompt_length then
     vim.api.nvim_buf_set_text(0, current_line_number-1, current_column_number-1, current_line_number-1, current_column_number, {""})

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -30,6 +30,7 @@ local function new_buf()
   api.nvim_buf_set_keymap(buf, 'n', '<CR>', "<Cmd>lua require('dap.repl').on_enter()<CR>", {})
   api.nvim_buf_set_keymap(buf, 'i', '<up>', "<Cmd>lua require('dap.repl').on_up()<CR>", {})
   api.nvim_buf_set_keymap(buf, 'i', '<down>', "<Cmd>lua require('dap.repl').on_down()<CR>", {})
+  api.nvim_buf_set_keymap(buf, 'i', '<backspace>', "<esc>:lua require('dap.repl').prompt_backspace()<CR>", {})
   vim.fn.prompt_setprompt(buf, 'dap> ')
   vim.fn.prompt_setcallback(buf, execute)
   return buf
@@ -270,6 +271,30 @@ end
 
 function M.on_down()
   select_history(1)
+end
+
+function M.prompt_backspace() --Expects to have entered normal mode before entering function, will return to insert mode
+  local currentLineNumber = vim.fn["line"](".")
+  local currentColumnNumber = vim.fn["col"](".")
+  local currentLineLength = vim.fn["col"]("$")
+  local currentLine = vim.api.nvim_buf_get_lines(0, currentLineNumber-1, currentLineNumber, false)[1]
+  local _, endPrompt = string.find(currentLine, "> ")
+
+  if endPrompt == nil then
+    endPrompt = 0
+  end
+
+  if currentColumnNumber ~= endPrompt then --Not beginning of the prompt
+    if currentColumnNumber == currentLineLength - 1 then --Not beginning of prompt and is the end of the line
+      vim.cmd([[normal x]])
+      vim.cmd([[startinsert!]])
+    else --Not beginning of prompt and is not the end of the line
+      vim.cmd([[normal x]])
+      vim.cmd([[startinsert]])
+    end
+  else --Beginning of prompt
+    vim.cmd([[startinsert]])
+  end
 end
 
 

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -282,7 +282,6 @@ function M.prompt_backspace()
   local currentCursor = vim.api.nvim_win_get_cursor(0)
   local currentLineNumber = currentCursor[1]
   local currentColumnNumber = currentCursor[2]
-  local currentLine = vim.api.nvim_buf_get_lines(0, currentLineNumber-1, currentLineNumber, false)[1]
   local promptLength = string.len(vim.fn['prompt_getprompt']('%'));
 
   if (currentColumnNumber) ~= promptLength then

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -283,13 +283,9 @@ function M.prompt_backspace()
   local currentLineNumber = currentCursor[1]
   local currentColumnNumber = currentCursor[2]
   local currentLine = vim.api.nvim_buf_get_lines(0, currentLineNumber-1, currentLineNumber, false)[1]
-  local _, endPromptPrefix = string.find(currentLine, "> ")
+  local promptLength = string.len(vim.fn['prompt_getprompt']('%'));
 
-  if endPromptPrefix == nil then
-    endPromptPrefix = 0
-  end
-
-  if (currentColumnNumber) ~= endPromptPrefix then
+  if (currentColumnNumber) ~= promptLength then
     vim.api.nvim_buf_set_text(0, currentLineNumber-1, currentColumnNumber-1, currentLineNumber-1, currentColumnNumber, {""})
     vim.api.nvim_win_set_cursor(0, {currentLineNumber, currentColumnNumber-1})
   end

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -276,12 +276,12 @@ end
 function M.prompt_backspace()
   -- Allows backspacing through previously set text when in a prompt.
   --
-  -- Note 1: nvim_buf_[get|set]_lines is 0 indexed vs vim [line|col](".") being 1 indexed
-  -- Note 2: insert mode cursor is after (+1) the column as opposed to in normal mode it would be on (+0) the column
-  -- Note 3: awkwardly nvim_win_set_cursor is 1 indexed for line and 0 indexed for column
+  -- Note 1: Insert mode cursor is after (+1) the column as opposed to in normal mode it would be on (+0) the column.
+  -- Note 2: nvim_win_[get|set]_cursor is (1, 0) indexed for (line, column) while nvim_buf_[get|set]_[lines|text] is 0 indexed for both.
 
-  local currentLineNumber = vim.fn["line"](".") 
-  local currentColumnNumber = vim.fn["col"](".")
+  local currentCursor = vim.api.nvim_win_get_cursor(0)
+  local currentLineNumber = currentCursor[1]
+  local currentColumnNumber = currentCursor[2]
   local currentLine = vim.api.nvim_buf_get_lines(0, currentLineNumber-1, currentLineNumber, false)[1]
   local _, endPromptPrefix = string.find(currentLine, "> ")
 
@@ -289,9 +289,9 @@ function M.prompt_backspace()
     endPromptPrefix = 0
   end
 
-  if (currentColumnNumber-1) ~= endPromptPrefix then
-    vim.api.nvim_buf_set_text(0, currentLineNumber-1, currentColumnNumber-2, currentLineNumber-1, currentColumnNumber-1, {""})
-    vim.api.nvim_win_set_cursor(0, {currentLineNumber, currentColumnNumber-2})
+  if (currentColumnNumber) ~= endPromptPrefix then
+    vim.api.nvim_buf_set_text(0, currentLineNumber-1, currentColumnNumber-1, currentLineNumber-1, currentColumnNumber, {""})
+    vim.api.nvim_win_set_cursor(0, {currentLineNumber, currentColumnNumber-1})
   end
 end
 


### PR DESCRIPTION
Add a remap for backspace in the repl to allow previously written text to be backspaced through.

This should resolve the issue in #119 and #291 without out any major side effects that I'm aware of.

I realize this is a pretty hacky workaround so I definitely won't be offended if it gets rejected.