### PR TITLE
Fix jump to frame in frames widget regression

### DIFF
--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -27,7 +27,7 @@ local function new_buf()
   if ok then
     api.nvim_buf_set_option(buf, 'path', path)
   end
-  api.nvim_buf_set_keymap(buf, 'n', '<CR>', "<Cmd>lua require('dap.ui').trigger_actions({ filter = 'Expand' })<CR>", {})
+  api.nvim_buf_set_keymap(buf, 'n', '<CR>', "<Cmd>lua require('dap.ui').trigger_actions({ mode = 'first' })<CR>", {})
   api.nvim_buf_set_keymap(buf, 'i', '<up>', "<Cmd>lua require('dap.repl').on_up()<CR>", {})
   api.nvim_buf_set_keymap(buf, 'i', '<down>', "<Cmd>lua require('dap.repl').on_down()<CR>", {})
   vim.fn.prompt_setprompt(buf, 'dap> ')

--- a/lua/dap/ui.lua
+++ b/lua/dap/ui.lua
@@ -353,6 +353,11 @@ function M.trigger_actions(opts)
     utils.notify('No action possible on: ' .. api.nvim_buf_get_lines(buf, lnum, lnum + 1, true)[1], vim.log.levels.INFO)
     return
   end
+  if opts.mode == 'first' then
+    local action = actions[1]
+    action.fn(layer, info.item, lnum, info.context)
+    return
+  end
   M.pick_if_many(
     actions,
     'Actions> ',

--- a/lua/dap/ui/widgets.lua
+++ b/lua/dap/ui/widgets.lua
@@ -10,7 +10,7 @@ local function new_buf()
   api.nvim_buf_set_option(buf, 'buftype', 'nofile')
   api.nvim_buf_set_option(buf, 'modifiable', false)
   api.nvim_buf_set_keymap(
-    buf, "n", "<CR>", "<Cmd>lua require('dap.ui').trigger_actions({ filter = 'Expand' })<CR>", {})
+    buf, "n", "<CR>", "<Cmd>lua require('dap.ui').trigger_actions({ mode = 'first' })<CR>", {})
   api.nvim_buf_set_keymap(
     buf, "n", "a", "<Cmd>lua require('dap.ui').trigger_actions()<CR>", {})
   api.nvim_buf_set_keymap(


### PR DESCRIPTION
After 16c22742df0c358a7f95ded813c08f98f5c42031 `<CR>` on frames no
longer jumped to the frame but instead resulted in a message that there
is no action on the frame.
