### PR TITLE
Ensure vim.empty_dict in config serializes as object

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -138,11 +138,12 @@ local function expand_config_variables(option)
     option = option()
   end
   if type(option) == "table" then
+    local mt = getmetatable(option)
     local result = {}
     for k, v in pairs(option) do
       result[expand_config_variables(k)] = expand_config_variables(v)
     end
-    return result
+    return setmetatable(result, mt)
   end
   if type(option) ~= "string" then
     return option


### PR DESCRIPTION
The variable expansion dropped metatables. That turned a `vim.empty_dict`
into a `{}` which gets serialized as list.

Fixes https://github.com/mfussenegger/nvim-dap/issues/378
