### PR TITLE
Update frames widgets on scopes changes

### DIFF
--- a/lua/dap/ui/widgets.lua
+++ b/lua/dap/ui/widgets.lua
@@ -155,6 +155,7 @@ M.scopes = {
 
 
 M.frames = {
+  refresh_listener = 'scopes',
   new_buf = new_buf,
   render = function(view)
     local session = require('dap').session()


### PR DESCRIPTION
The frames widget only updated on `event_stopped`, that missed active
frame changes - like via `.down` or `.up`.
`scopes` is called after each frame change.

Closes https://github.com/mfussenegger/nvim-dap/issues/390
