### PR TITLE
Split newlines in output from REPL commands

### DIFF
--- a/lua/dap/ui.lua
+++ b/lua/dap/ui.lua
@@ -437,8 +437,8 @@ function M.layer(buf)
             .. vim.inspect(xs)
           ))
         end
-        text = text:gsub('\n', '\\n')
-        api.nvim_buf_set_lines(buf, i, i + 1, true, {text})
+        text = vim.split(text, '\n', {trimempty = true})
+        api.nvim_buf_set_lines(buf, i, i + 1, true, text)
         if hl_regions then
           for _, hl_region in pairs(hl_regions) do
             api.nvim_buf_add_highlight(
@@ -446,8 +446,11 @@ function M.layer(buf)
           end
         end
 
-        local end_col = math.max(0, #text - 1)
-        local mark_id = api.nvim_buf_set_extmark(buf, ns, i, 0, {end_col=end_col})
+        local end_col = math.max(0, #text[#text] - 1)
+        local mark_id = api.nvim_buf_set_extmark(buf, ns, i, 0, {
+          end_row = i + #text - 1,
+          end_col = end_col
+        })
         marks[mark_id] = { mark_id = mark_id, item = item, context = context }
       end
       api.nvim_buf_set_option(buf, 'modifiable', modifiable)


### PR DESCRIPTION
For example, when using LLDB one can use the following command in the
REPL to create the following output:

    dap> `p $rsp
    (lldb) p $rsp\n(unsigned long) $0 = 140732920752800\n

Note that the returned text contains newline characters (\n), but it is
all on a single line.

This commit splits the output on these newline characters so that the
output instead looks like this:

    dap> `p $rsp
    (lldb) p $rsp
    (unsigned long) $0 = 140732920752800
