### PR TITLE
Handle nil capabilities in terminate

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -360,8 +360,9 @@ end
 
 function M.terminate(terminate_opts, disconnect_opts, cb)
   if session then
-    if session.capabilities.supportsTerminateRequest then
-      session.capabilities.supportsTerminateRequest = false
+    local capabilities = session.capabilities or {}
+    if capabilities.supportsTerminateRequest then
+      capabilities.supportsTerminateRequest = false
       local opts = terminate_opts or vim.empty_dict()
       session:request('terminate', opts, function(err)
         assert(not err, vim.inspect(err))


### PR DESCRIPTION
If the debug adapter configuration is broken the session may not
initialize fully but be left in a semi-initialized state.. Terminate
should still work despite that.
