### PR TITLE
feat(session) adds focus_terminal option

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -318,7 +318,6 @@ Some debug adapters support launching the debugee in a terminal, but don't
 provide an option to choose between integrated terminal or external terminal.
 `nvim-dap` provides an option to force the external terminal.
 
-
 >
 
   lua << EOF
@@ -328,10 +327,8 @@ provide an option to choose between integrated terminal or external terminal.
 
 <
 
-
 If you're using the integrated terminal, you can configure the command
 that is used to create a split window:
-
 
 >
 
@@ -339,10 +336,23 @@ that is used to create a split window:
   local dap = require('dap')
   dap.defaults.fallback.terminal_win_cmd = '50vsplit new'
   EOF
+
 <
 
 The `terminal_win_cmd` defaults to `belowright new`.
 
+Be default `dap` opens the integrated terminal but keeps focus on the current
+buffer. If you rather have focus to be shifted to the terminal when it opens
+you can configure:
+
+>
+
+  lua << EOF
+  local dap = require('dap')
+  dap.defaults.fallback.focus_terminal = true
+  EOF
+
+<
 
 `fallback` can be replaced with the |dap-adapter| type to have type
 specific terminal configurations.

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -51,6 +51,7 @@ M.defaults = setmetatable(
       -- type SteppingGranularity = 'statement' | 'line' | 'instruction'
       stepping_granularity = 'statement';
       terminal_win_cmd = 'belowright new';
+      focus_terminal = false;
     },
   },
   {

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -128,7 +128,9 @@ local function run_in_terminal(self, request)
     cwd = (body.cwd and body.cwd ~= '') and body.cwd or nil
   }
   local jobid = vim.fn.termopen(body.args, opts)
-  api.nvim_set_current_win(cur_win)
+  if not dap().defaults[self.config.type].focus_terminal then
+      api.nvim_set_current_win(cur_win)
+  end
   if jobid == 0 or jobid == -1 then
     log.error('Could not spawn terminal', jobid, request)
     self:response(request, {


### PR DESCRIPTION
adds option to focus the terminal when it's opened (default to `false` which is the current behaviour).