### PR TITLE
fix: Schedule vim notify

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -367,7 +367,7 @@ function M.terminate(terminate_opts, disconnect_opts, cb)
       local opts = terminate_opts or vim.empty_dict()
       session:request('terminate', opts, function(err)
         assert(not err, vim.inspect(err))
-        vim.notify('Session terminated')
+        vim.schedule(function () vim.notify('Session terminated') end)
         if cb then
           cb()
         end
@@ -377,7 +377,7 @@ function M.terminate(terminate_opts, disconnect_opts, cb)
       M.disconnect(opts, cb)
     end
   else
-    vim.notify('No active session')
+    vim.schedule(function () vim.notify('No active session') end)
     if cb then
       cb()
     end
@@ -605,7 +605,7 @@ end
 
 
 function M.omnifunc(findstart, base)
-  vim.notify("dap.omnifunc is deprecated. Use require('dap.repl').omnifunc instead.", vim.log.levels.WARN)
+  vim.schedule(function () vim.notify("dap.omnifunc is deprecated. Use require('dap.repl').omnifunc instead.", vim.log.levels.WARN) end)
   return lazy.repl.omnifunc(findstart, base)
 end
 

--- a/lua/dap/utils.lua
+++ b/lua/dap/utils.lua
@@ -92,7 +92,7 @@ function M.get_visual_selection_text()
 end
 
 function M.notify(msg, log_level)
-  vim.notify(msg, log_level, {title = 'DAP'})
+  vim.schedule(function () vim.notify(msg, log_level, {title = 'DAP'}) end)
 end
 
 return M


### PR DESCRIPTION
**Why** is the change needed?

To prevent the following error:

```
Error executing luv callback:
vim.lua:431: E5560: nvim_err_writeln must not be called in a lua loop callback
stack traceback:
        [C]: in function 'nvim_err_writeln'
        vim.lua:431: in function 'notify'
        .../dotfiles/vim/pack/bundle/opt/nvim-dap/lua/dap/utils.lua:95: in function 'notify'
        ...bm/.config/nvim/pack/bundle/opt/nvim-dap/lua/dap/rpc.lua:69: in function <...bm/.config/nvim/pack/bundle/opt/nvim-dap/lua/dap
/rpc.lua:67>
```