### PR TITLE
Remove trailing newline when rendering variables

### DIFF
--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -88,7 +88,7 @@ function M.print_stackframes(frames)
   frames = frames or (session and session.threads[session.stopped_thread_id] or {}).frames or {}
   local context = {}
   M.append('(press enter on line to jump to frame)')
-  local start = ui.get_last_lnum(repl.buf)
+  local start = api.nvim_buf_line_count(repl.buf) - 1
   local render_frame = require('dap.entity').frames.render_item
   context.actions = {
     {

--- a/lua/dap/ui.lua
+++ b/lua/dap/ui.lua
@@ -371,11 +371,6 @@ function M.trigger_actions(opts)
 end
 
 
-function M.get_last_lnum(bufnr)
-  return api.nvim_buf_call(bufnr, function() return vim.fn.line('$') - 1 end)
-end
-
-
 local layers = {}
 
 function M.get_layer(buf)
@@ -413,7 +408,7 @@ function M.layer(buf)
     render = function(xs, render_fn, context, start, end_)
       local modifiable = api.nvim_buf_get_option(buf, 'modifiable')
       api.nvim_buf_set_option(buf, 'modifiable', true)
-      start = start or M.get_last_lnum(buf)
+      start = start or (api.nvim_buf_line_count(buf) - 1)
       end_ = end_ or start
       render_fn = render_fn or tostring
       if end_ > start then

--- a/tests/ui_spec.lua
+++ b/tests/ui_spec.lua
@@ -15,13 +15,12 @@ describe('ui', function()
         { label = "", x = 3 },
         { label = "dd", x = 4 },
       }
-      layer.render(items,render_item)
+      layer.render(items, render_item)
       local lines = api.nvim_buf_get_lines(buf, 0, -1, true)
       assert.are.same({
         'aa',
         '',
         'dd',
-        ''
       }, lines)
 
       assert.are.same(3, vim.tbl_count(layer.__marks))
@@ -38,7 +37,6 @@ describe('ui', function()
         'bb',
         '',
         'dd',
-        ''
       }, lines)
       assert.are.same('aa', layer.get(0).item.label)
       assert.are.same('bb', layer.get(1).item.label)
@@ -58,7 +56,6 @@ describe('ui', function()
         'bbbb',
         '',
         'dd',
-        ''
       }, lines)
       assert.are.same('aa', layer.get(0).item.label)
       assert.are.same('bbb', layer.get(1).item.label)
@@ -93,7 +90,6 @@ describe('ui', function()
       'root',
       '  a',
       '  b',
-      '',
     }, lines)
 
     it('can expand an element with children', function()
@@ -106,7 +102,6 @@ describe('ui', function()
         '  a',
         '  b',
         '    c',
-        '',
       }, lines)
 
       lnum = 3
@@ -119,7 +114,6 @@ describe('ui', function()
         '  b',
         '    c',
         '      d',
-        '',
       }, lines)
     end)
 
@@ -135,7 +129,6 @@ describe('ui', function()
         '  b',
         '    c',
         '      d',
-        '',
       }, lines)
     end)
 
@@ -148,7 +141,6 @@ describe('ui', function()
         'root',
         '  a',
         '  b',
-        '',
       }, lines)
     end)
 
@@ -162,7 +154,6 @@ describe('ui', function()
         '  a',
         '  b',
         '    c',
-        '',
       }, lines)
       layer.render({}, tostring, nil, 0, -1)
       local subtree = ui.new_tree(opts)
@@ -171,7 +162,6 @@ describe('ui', function()
       assert.are.same({
         'b',
         '  c',
-        '',
       }, lines)
     end)
   end)


### PR DESCRIPTION
I'm not sure yet if this behavior is better. Happy to get some feedback
