### PR TITLE
Added sourceModified flag to payload to make Unity debugger work

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -484,6 +484,7 @@ do
           path = path;
           name = vim.fn.fnamemodify(path, ':t')
         };
+        sourceModified = false;
         breakpoints = buf_bps;
         lines = vim.tbl_map(function(x) return x.line end, buf_bps);
       }


### PR DESCRIPTION
Without this flag VS code plugin was crashing on adding breakpoints.
I am not sure about making it always false though. I have no idea how to detect that.