### PR TITLE
Use nvim_buf_set_lines instead of appendbufline in repl.append

### DIFF
--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -289,8 +289,12 @@ function M.append(line, lnum)
   if #lines > 1 and lines[#lines] == '' then
     table.remove(lines)
   end
-  lnum = lnum or api.nvim_buf_line_count(buf) - 1
-  vim.fn.appendbufline(buf, lnum, lines)
+  if lnum == '$' or not lnum then
+    lnum = api.nvim_buf_line_count(buf) - 1
+    api.nvim_buf_set_lines(buf, -1, -1, true, lines)
+  else
+    api.nvim_buf_set_lines(buf, lnum, lnum, true, lines)
+  end
   return lnum
 end
 


### PR DESCRIPTION
Looks like using appendbufline can cause hiccups and trigger events for
other buffers.

Closes https://github.com/mfussenegger/nvim-dap/issues/465
