### PR TITLE
Remove DAPInstall reference from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ that's not listed.
 - Debug adapter installations are out of scope. It's not the business of an
   editor plugin to re-invent a package manager. Use your system package
   manager. Use Nix. Use Ansible.
-  If you disagree, check out [DAPInstall][14].
 
 - Vim support. It's not going to happen. Use [vimspector][2] instead.
 
@@ -130,7 +129,6 @@ time.
 [11]: https://github.com/junegunn/vim-plug
 [12]: https://github.com/wbthomason/packer.nvim
 [13]: https://microsoft.github.io/debug-adapter-protocol/implementors/adapters/
-[14]: https://github.com/Pocco81/DAPInstall.nvim
 [15]: https://github.com/rcarriga/nvim-dap-ui
 [demo]: https://user-images.githubusercontent.com/38700/124292938-669a7100-db56-11eb-93b8-77b66994fc8a.gif
 


### PR DESCRIPTION
The repository got archived
