### PR TITLE
error E5560 on terminate with 'jbyuki/one-small-step-for-vimkind'

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -842,7 +842,12 @@ end
 
 
 function Session:close()
-  vim.fn.sign_unplace(ns_pos)
+  -- can't always be called safely, returns the below with
+  -- jbyuki/one-small-step-for-vimkind
+  -- E5560: vimL function must not be called in a lua loop callback
+  vim.schedule(function()
+    vim.fn.sign_unplace(ns_pos)
+  end)
   self.threads = {}
   self.message_callbacks = {}
   self.message_requests = {}


### PR DESCRIPTION
As per the title, when using https://github.com/jbyuki/one-small-step-for-vimkind terminate session fails with:
```
E5560: vimL function must not be called in a lua loop callback
```

Due to:
https://github.com/mfussenegger/nvim-dap/blob/3d0575a777610b364fea745b85ad497d56b8009a/lua/dap/session.lua#L845

This wraps it in a pcall which solves the problem (can now safely terminate OSV sessions).