### PR TITLE
Run disconnect timeout callback in main loop

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -641,7 +641,7 @@ function M.attach(adapter, config, opts, bwc_dummy)
   assert(adapter.port, 'Adapter used with attach must have a port property')
   session = require('dap.session'):connect(adapter, opts, function(err)
     assert(not err, vim.inspect(err))
-    session:initialize(config, adapter)
+    session:initialize(config)
   end)
   return session
 end
@@ -664,7 +664,7 @@ end
 --
 function M.launch(adapter, config, opts)
   session = require('dap.session'):spawn(adapter, opts)
-  session:initialize(config, adapter)
+  session:initialize(config)
   return session
 end
 

--- a/lua/dap/progress.lua
+++ b/lua/dap/progress.lua
@@ -41,7 +41,7 @@ function M.status()
   if not session then
     return ''
   end
-  if not (vim.bo.buftype == '') then
+  if vim.bo.buftype ~= '' then
     return ''
   end
   local msg = M.poll_msg() or last_msg

--- a/tests/server.lua
+++ b/tests/server.lua
@@ -121,7 +121,10 @@ function M.spawn()
     adapter = {
       type = 'server',
       host = host;
-      port = server:getsockname().port
+      port = server:getsockname().port,
+      options = {
+        disconnect_timeout_sec = 0.1
+      },
     },
     spy = spy,
     stop = function()


### PR DESCRIPTION
Regular callbacks are scheduled in the main event loop. The same should
be done with if the callback is triggered due to a timeout to ensure
vimL functions can be used.

Fixes:

    nvim-dap/lua/dap/session.lua:846: E5560: vimL function must not be called in a lua loop callback
    stack traceback:
    	[C]: in function 'sign_unplace'
    	...nvim-dap/lua/dap/session.lua:846: in function 'close'
    	...nvim-dap/lua/dap/session.lua:991: in function 'callback'
    	...nvim-dap/lua/dap/session.lua:880: in function <...nvim-dap/lua/dap/session.lua:872
