### PR TITLE
Add a threads widget

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -821,6 +821,7 @@ Available widgets entities:
 - scopes
 - frames
 - expression
+- threads
 
 
 Available widget builder functions:

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -52,6 +52,7 @@ M.defaults = setmetatable(
       stepping_granularity = 'statement';
       terminal_win_cmd = 'belowright new';
       focus_terminal = false;
+      auto_continue_if_many_stopped = true;
     },
   },
   {

--- a/lua/dap/entity.lua
+++ b/lua/dap/entity.lua
@@ -223,9 +223,9 @@ M.frames = frames
 function frames.render_item(frame)
   local session = require('dap').session()
   if session and frame.id == session.current_frame.id then
-    return '→ ' .. frame.name
+    return '→ ' .. frame.name .. ':' .. frame.line
   else
-    return '  ' .. frame.name
+    return '  ' .. frame.name .. ':' .. frame.line
   end
 end
 
@@ -247,7 +247,7 @@ end
 function threads_spec.render_child(thread_or_frame)
   if thread_or_frame.line then
     -- it's a frame
-    return thread_or_frame.name
+    return frames.render_item(thread_or_frame)
   end
   if thread_or_frame.stopped then
     return '⏸️ ' .. thread_or_frame.name

--- a/lua/dap/entity.lua
+++ b/lua/dap/entity.lua
@@ -250,9 +250,9 @@ function threads_spec.render_child(thread_or_frame)
     return thread_or_frame.name
   end
   if thread_or_frame.stopped then
-    return '◀ ' .. thread_or_frame.name
+    return '⏸️ ' .. thread_or_frame.name
   else
-    return '〓' .. thread_or_frame.name
+    return '▶️ ' .. thread_or_frame.name
   end
 end
 

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -351,13 +351,12 @@ end
 
 
 local function get_top_frame(frames)
-  local top_frame = nil
   for _, frame in pairs(frames) do
-    if not top_frame and frame.source and frame.source.path then
-      top_frame = frame
+    if frame.source and frame.source.path then
+      return frame
     end
   end
-  return top_frame and top_frame or next(frames)
+  return next(frames)
 end
 
 

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -424,12 +424,12 @@ function Session:event_stopped(stopped)
     local frames = response.stackFrames
     thread.frames = frames
     local current_frame = get_top_frame(frames)
-    self.current_frame = current_frame
     if not current_frame then
       utils.notify('Debug adapter stopped at unavailable location', vim.log.levels.WARN)
       return
     end
     if should_jump then
+      self.current_frame = current_frame
       jump_to_frame(self, current_frame, stopped.preserveFocusHint)
       self:_request_scopes(current_frame)
     end

--- a/lua/dap/ui.lua
+++ b/lua/dap/ui.lua
@@ -1,5 +1,6 @@
 local api = vim.api
 local utils = require('dap.utils')
+local if_nil = utils.if_nil
 local M = {}
 
 
@@ -82,6 +83,7 @@ function M.new_tree(opts)
   opts.render_child = opts.render_child or opts.render_parent
   local compute_actions = opts.compute_actions or function() return {} end
   local extra_context = opts.extra_context or {}
+  local implicit_expand_action = if_nil(opts.implicit_expand_action, true)
 
   local self  -- forward reference
 
@@ -182,7 +184,7 @@ function M.new_tree(opts)
   local function render_all_expanded(layer, value, indent)
     indent = indent or 2
     local context = {
-      actions = { { label ='Expand', fn = self.toggle, }, },
+      actions = implicit_expand_action and { { label ='Expand', fn = self.toggle, }, } or {},
       indent = indent,
       compute_actions = compute_actions,
     }

--- a/lua/dap/ui.lua
+++ b/lua/dap/ui.lua
@@ -229,6 +229,9 @@ function M.new_tree(opts)
     render = function(layer, value, on_done)
       layer.render({value}, opts.render_parent)
       if not opts.has_children(value) then
+        if on_done() then
+          on_done()
+        end
         return
       end
       if not is_expanded(value) then

--- a/lua/dap/ui/widgets.lua
+++ b/lua/dap/ui/widgets.lua
@@ -174,6 +174,13 @@ M.threads = {
       return
     end
 
+    if session.dirty.threads then
+      session:update_threads(function()
+        M.threads.render(view)
+      end)
+      return
+    end
+
     local tree = view.tree
     if not tree then
       local spec = vim.deepcopy(require('dap.entity').threads.tree_spec)

--- a/lua/dap/ui/widgets.lua
+++ b/lua/dap/ui/widgets.lua
@@ -159,6 +159,39 @@ M.scopes = {
 }
 
 
+M.threads = {
+  refresh_listener = 'event_thread',
+  new_buf = function()
+    local buf = new_buf()
+    api.nvim_buf_set_name(buf, 'dap-threads')
+    return buf
+  end,
+  render = function(view)
+    local layer = view.layer()
+    local session = require('dap').session()
+    if not session then
+      layer.render({'No active session'})
+      return
+    end
+
+    local tree = view.tree
+    if not tree then
+      local spec = vim.deepcopy(require('dap.entity').threads.tree_spec)
+      spec.extra_context = { view = view }
+      tree = ui.new_tree(spec)
+      view.tree = tree
+    end
+
+    local root = {
+      id = 0,
+      name = 'Threads',
+      threads = vim.tbl_values(session.threads)
+    }
+    tree.render(layer, root)
+  end,
+}
+
+
 M.frames = {
   refresh_listener = 'scopes',
   new_buf = function()

--- a/lua/dap/utils.lua
+++ b/lua/dap/utils.lua
@@ -95,4 +95,10 @@ function M.notify(msg, log_level)
   vim.notify(msg, log_level, {title = 'DAP'})
 end
 
+
+function M.if_nil(x, default)
+  return x == nil and default or x
+end
+
+
 return M

--- a/tests/debugpy_spec.lua
+++ b/tests/debugpy_spec.lua
@@ -48,6 +48,10 @@ describe('dap with debugpy', function()
       events.setBreakpoints = resp
     end
     dap.listeners.after.event_stopped['dap.tests'] = function()
+      vim.wait(1000, function()
+        local session = dap.session()
+        return session.stopped_thread_id ~= nil
+      end)
       dap.continue()
       events.stopped = true
     end


### PR DESCRIPTION
Changes the threads management slightly so that threads are only updated on a stopped event if they're dirty (new threads started or some exited). This should make stepping a bit faster if there are many threads.

This now also allows to have several stopped threads in parallel. By default only if threads are manually paused. Stopped events due to exceptions or breakpoints will still get continued automatically if there is already a stopped thread used for stepping around.

https://user-images.githubusercontent.com/38700/161313066-236947ed-0340-4b97-9dc1-b3f0d70e6d53.mp4

