### PR TITLE
Unset breakpoints globally when run_to_cursor

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -182,7 +182,8 @@ function Session:event_initialized()
     end
   end
 
-  self:set_breakpoints(nil, function()
+  local bps = breakpoints.get()
+  self:set_breakpoints(bps, function()
     if self.capabilities.exceptionBreakpointFilters then
       self:set_exception_breakpoints(dap().defaults[self.config.type].exception_breakpoints, nil, on_done)
     else
@@ -519,8 +520,7 @@ do
     end
   end
 
-  function Session:set_breakpoints(bufexpr, on_done)
-    local bps = breakpoints.get(bufexpr)
+  function Session:set_breakpoints(bps, on_done)
     local num_requests = vim.tbl_count(bps)
     if num_requests == 0 then
       if on_done then

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -537,7 +537,19 @@ do
           name = vim.fn.fnamemodify(path, ':t')
         };
         sourceModified = false;
-        breakpoints = buf_bps;
+        breakpoints = vim.tbl_map(
+          function(bp)
+            -- trim extra information like the state
+            return {
+              line = bp.line,
+              column = bp.column,
+              condition = bp.condition,
+              hitCondition = bp.hitCondition,
+              logMessage = bp.logMessage,
+            }
+          end,
+          buf_bps
+        ),
         lines = vim.tbl_map(function(x) return x.line end, buf_bps);
       }
       self:request('setBreakpoints', payload, function(err1, resp)


### PR DESCRIPTION
Consider the scenario below:

1. User sets Breakpoint 1 in Buffer A
2. User sets Breakpoint 2 in Buffer A, which is a few lines below
   Breakpoint 1
3. User starts debugging
4. User opens Buffer B, in which a method is supposed to be called after
   Breakpoint 1 and 2
5. User uses run_to_cursor in Buffer B

Issues with current implementation:

1. Program will pause at Breakpoint 2 prior to cursor line in Buffer B,
   since breakpoints in Buffer A are not cleared
2. Temporary breakpoint in Buffer B will not be cleared, since Buffer B
   was not in the list of buffers that've got breakpoints before the
   run_to_cursor operation, and it hasn't got other breakpoints after
   run_to_cursor either

This PR fixes the above issue by sending setBreakpoints requests for all
involved buffers.

---

I'm new to Lua so hopefully this doesn't look too bad :P