### PR TITLE
feat: custom console

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -54,6 +54,7 @@ M.defaults = setmetatable(
       focus_terminal = false;
       auto_continue_if_many_stopped = true;
     },
+    open_console = false;
   },
   {
     __index = function(tbl, key)


### PR DESCRIPTION
Hey there :smile: So I'm trying to implement https://github.com/rcarriga/nvim-dap-ui/issues/88 but the way the integrated console works right now makes it impossible to hide the buffer without shutting down the process. The current method also requires a window to be open when starting. I was originally going to make a PR switching to using `jobstart` and `nvim_create_term` to allow background operation but then I also needed control over the buffer etc so thought it'd make more sense to just make it totally customisable.

This allows the user to set an `open_console` setting (I'm not sure if I've placed this setting in the correct place) which will take the request body and return a PID. My use case will look something like this (and will be set by dapui)
```lua
    dap.defaults.open_console = function(body)
      local jobid

      local chan = api.nvim_open_term(console_buf, {
        on_input = function(_, _, _, data)
          pcall(api.nvim_chan_send, jobid, data)
        end,
      })

      local opts = {
        clear_env = false,
        env = next(body.env or {}) and body.env or vim.empty_dict(),
        cwd = (body.cwd and body.cwd ~= "") and body.cwd or nil,
        height = height,
        width = width,
        pty = true,
        on_stdout = function(_, data)
          data = table.concat(data, "\r\n")
          api.nvim_chan_send(chan, data)
        end,
      }

      jobid = vim.fn.jobstart(body.args, opts)

      return vim.fn.jobpid(jobid)
    end
  end,

```