### PR TITLE
Adjust breakpoint line numbers based on server response

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -568,7 +568,12 @@ do
         if err1 then
           utils.notify('Error setting breakpoints: ' .. err1.message, vim.log.levels.ERROR)
         else
-          for _, bp in pairs(resp.breakpoints) do
+          for i, bp in pairs(resp.breakpoints) do
+            local payload_bp = payload.breakpoints[i]
+            if bp.line ~= payload_bp.line then
+                breakpoints.remove(bufnr, payload_bp.line, bp)
+                breakpoints.toggle({ replace = true }, bufnr, bp.line)
+            end
             breakpoints.set_state(bufnr, bp.line, bp)
             if not bp.verified then
               log.info('Server rejected breakpoint', bp)


### PR DESCRIPTION
Hey there,

here's a small improvement on the handling of the `setBreakpoints` response :)

According to the [specification](https://microsoft.github.io/debug-adapter-protocol/specification#Types_Breakpoint), the `line` number returned in the response of `setBreakpoints` indicates the actual start of the range covered by the breakpoint i.e. the following behavior would be expected:

**Request**
```
   1 
   2 
B  3 <-- set breakpoint in VIM here and send line = 3 in payload
   4 // Some Code
   5 bar();
```

**Response**
```
   1 
   2 
   3 
   4 // Some Code
B  5 bar(); <-- server sets breakpoint on the next possible line and returns line = 5 in the response
```

This PR adjusts the response handler to compare the returned breakpoints with the ones originally send in the request and in case their line numbers differ moves them to the line assigned by the server.

Comparing the breakpoints based on the indices should be fine as the specification states:

> The breakpoints returned are in the same order as the elements of the ‘breakpoints’
