### PR TITLE
Use config name in integrated terminal buffer name

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -233,7 +233,7 @@ local function run_in_terminal(self, request)
     end
     terminal_width = terminal_win and api.nvim_win_get_width(terminal_win) or 80
     terminal_height = terminal_win and api.nvim_win_get_height(terminal_win) or 40
-    api.nvim_buf_set_name(terminal_buf, '[dap-terminal] ' .. body.args[1])
+    api.nvim_buf_set_name(terminal_buf, '[dap-terminal] ' .. self.config.name or body.args[1])
   end
   local ok, path = pcall(api.nvim_buf_get_option, cur_buf, 'path')
   if ok then


### PR DESCRIPTION
The command in the args is often the debug-adapter executable, or a
runtime like python/java, etc. Using the config name is probably more
useful.
