### PR TITLE
Fix the precedence operation in session.lua.

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -233,7 +233,7 @@ local function run_in_terminal(self, request)
     end
     terminal_width = terminal_win and api.nvim_win_get_width(terminal_win) or 80
     terminal_height = terminal_win and api.nvim_win_get_height(terminal_win) or 40
-    api.nvim_buf_set_name(terminal_buf, '[dap-terminal] ' .. self.config.name or body.args[1])
+    api.nvim_buf_set_name(terminal_buf, '[dap-terminal] ' .. (self.config.name or body.args[1]))
   end
   local ok, path = pcall(api.nvim_buf_get_option, cur_buf, 'path')
   if ok then


### PR DESCRIPTION
Adds fix for precedence operation that was not taken into account. On master at the moment the concat takes precedence over the OR operator which was causing a runtime error when the config.name was null, due to trying to concat a nil value. 