### PR TITLE
Handle nil response on setBreakpoints

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -700,7 +700,7 @@ do
       self:request('setBreakpoints', payload, function(err1, resp)
         if err1 then
           utils.notify('Error setting breakpoints: ' .. err1.message, vim.log.levels.ERROR)
-        else
+        elseif resp then
           for _, bp in pairs(resp.breakpoints) do
             breakpoints.set_state(bufnr, bp.line, bp)
             if not bp.verified then


### PR DESCRIPTION
Some debug adapters don't play nice and send neither an error nor a
response if setting breakpoints if the sessions is just getting
terminated.

This can happen if you disconnect and immediately remove a breakpoint.
