### PR TITLE
Remove notify call on allThreadsStopped

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -532,10 +532,6 @@ function Session:event_stopped(stopped)
 
   if stopped.allThreadsStopped then
     progress.report('All threads stopped')
-    utils.notify(
-      'All threads stopped. ' .. stopped.reason and 'Reason: ' .. stopped.reason or '',
-      vim.log.levels.INFO
-    )
     for _, thread in pairs(self.threads) do
       thread.stopped = true
     end


### PR DESCRIPTION
The notify was intended for edge cases, assuming that there would be no
jump action, but 688cb52d8bfbb237531056b24d727f33ff4bedfa changed that
and made it more common.
