### PR TITLE
Workaround lua-language-server vim.notify warning

### DIFF
--- a/tests/integration_spec.lua
+++ b/tests/integration_spec.lua
@@ -133,7 +133,8 @@ describe('dap with fake server', function()
       })
     end
     local captured_msg
-    vim.notify = function(msg)
+    vim.notify = function(...)
+      local msg = select(1, ...)
       captured_msg = msg
     end
     session:event_stopped({


### PR DESCRIPTION
The monkey patching in the test messed with lua-language-server, leading
to false warnings about the number of parameters.
