### PR TITLE
tests: add docker container for testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:edge
+
+RUN apk add git neovim python3 --update && \
+  # create symlink for python, because lua only calls python not python3
+  ln -s $(which python3) /usr/bin/python 
+
+RUN git clone --depth 1 https://github.com/nvim-lua/plenary.nvim /root/.local/share/nvim/site/pack/vendor/start/plenary.nvim
+COPY lua/ /root/.local/share/nvim/site/pack/vendor/start/lua
+COPY tests/ /root/.local/share/nvim/site/pack/vendor/start/tests
+WORKDIR /root/.local/share/nvim/site/pack/vendor/start/
+ENTRYPOINT [ "nvim" ]
+

--- a/README.md
+++ b/README.md
@@ -109,6 +109,20 @@ clarify whether the change is in scope of the nvim-dap core.
 Please keep pull requests focused and don't change multiple things at the same
 time.
 
+### Running tests
+
+Tests can be run inside a docker container: 
+
+To run all tests:
+```console
+$ ./tests/run.sh
+```
+
+To run only a specific test file:
+```console
+$ ./tests/run.sh tests/debugpy_spec.lua
+```
+
 ## Features
 
 - [x] launch debug adapter

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -ex
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && /bin/pwd )"
+
+docker build -t nvim-dap-tests $DIR/..
+
+FILE=$1
+# test whole package
+if [[ -z "$FILE" ]]; then
+  docker run -t nvim-dap-tests --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal.vim'}"
+else 
+  docker run -t nvim-dap-tests --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedFile $FILE"
+fi
+

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && /bin/pwd )"
 


### PR DESCRIPTION
Tests are currently a bit weird to run locally, because you need to have plenary installed via git and not by e.g. packer.

This PR adds a dockerfile and a script to execute the tests inside an isolated container with nvim, plenary and python installed. 

Signed-off-by: Höhl, Lukas <lukas.hoehl@accso.de>