### PR TITLE
feat: jump to file instead of source if source matches file content

### DIFF
--- a/lua/dap/utils.lua
+++ b/lua/dap/utils.lua
@@ -124,5 +124,9 @@ function M.if_nil(x, default)
   return x == nil and default or x
 end
 
+function M.get_buffer_content_as_string(bufnr)
+  return table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false))
+end
+
 
 return M


### PR DESCRIPTION
This PR makes it so that if we stop, and `sourceReference = 1`, we will still jump to the actual file on disk instead of to an unnamed temporary buffer if the file contents match.

This avoids two problems which are present with the current approach:
1. The constant creation of unnamed buffers which have to be manually closed.
2. The loss of buffer-local information such as diagnostics and test progress (e.g. in the case of integration with neotest)

It also contributes to a more seamless experience over all, in my opinion.

(There might be a better way to decide whether or we should jump to the local file or the DAP-supplied source, than to compare the buffer contents. I'm all ears for suggestions!)

If this is something we want to add, is this something we should perhaps hide behind an option?
Another approach would then be to add an option to always goto the file on disk regardless of content differences, if the user so wanted.

What do you think?