### PR TITLE
Extend server adapter definition to support spawning executable's

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -97,12 +97,28 @@ For `executable` the following options are supported:
 For `server` the following options are supported:
 
 >
-    host?: string       -- host to connect to, defaults to 127.0.0.1
-    port:  number       -- port to connect to
-    id?: string         -- Identifier of the adapter. This is used for the
-                           `adapterId` property of the initialize request.
-                           For most debug adapters setting this is not
-                           necessary.
+    host?: string             -- host to connect to, defaults to 127.0.0.1
+    port:  number|"${port}"   -- port to connect to.
+                              -- If "${port}" nvim-dap resolves a free port.
+                              -- This is intended to be used with
+                              -- `executable.args` further below below
+    id?: string               -- Identifier of the adapter. This is used for the
+                                 `adapterId` property of the initialize request.
+                                  For most debug adapters setting this is not
+                                  necessary.
+
+    -- nvim-dap can optionally launch the debug-adapter on each new debug session
+    -- And then connect via TCP.
+    --
+    executable?: {
+      command: string       -- command that spawns the server
+      args?: string[]       -- command arguments
+                            -- ${port} used in the args is replaced with a
+                            -- dynamically resolved free port number
+      detached?: boolean    -- Spawn the debug adapter in detached mode.
+                            -- Defaults to true.
+      cwd?: string          -- Working directory
+    }
 
 
 Both types support the following additional options:

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -102,6 +102,13 @@ local DAP_QUICKFIX_CONTEXT = DAP_QUICKFIX_TITLE
 ---@field type "server"
 ---@field host string|nil
 ---@field port number
+---@field executable nil|ServerAdapterExecutable
+
+---@class ServerAdapterExecutable
+---@field command string
+---@field args nil|string[]
+---@field cwd nil|string
+---@field detached nil|boolean
 
 
 --- Adapter definitions. See `:help dap-adapter` for more help
@@ -698,13 +705,12 @@ function M.attach(adapter, config, opts, bwc_dummy)
     utils.notify('Config needs the `request` property which must be one of `attach` or `launch`', vim.log.levels.ERROR)
     return
   end
-  assert(adapter.host, 'Adapter used with attach must have a host property')
   assert(adapter.port, 'Adapter used with attach must have a port property')
   session = require('dap.session'):connect(adapter, opts, function(err)
     if err then
       vim.schedule(function()
         utils.notify(
-          string.format("Couldn't connect to %s:%s: %s", adapter.host, adapter.port, err),
+          string.format("Couldn't connect to %s:%s: %s", adapter.host or '127.0.0.1', adapter.port, err),
           vim.log.levels.ERROR
         )
         if session then

--- a/lua/dap/utils.lua
+++ b/lua/dap/utils.lua
@@ -116,7 +116,13 @@ function M.get_visual_selection_text()
 end
 
 function M.notify(msg, log_level)
-  vim.notify(msg, log_level, {title = 'DAP'})
+  if vim.in_fast_event() then
+    vim.schedule(function()
+      vim.notify(msg, log_level, {title = 'DAP'})
+    end)
+  else
+    vim.notify(msg, log_level, {title = 'DAP'})
+  end
 end
 
 

--- a/tests/integration_spec.lua
+++ b/tests/integration_spec.lua
@@ -116,7 +116,7 @@ describe('dap with fake server', function()
         threads = { { id = 1, name = 'thread1' }, }
       })
     end
-    server.client.stackTrace = function(self, request)
+    server.client.stackTrace = vim.schedule_wrap(function(self, request)
       self:send_response(request, {
         stackFrames = {
           {
@@ -131,7 +131,7 @@ describe('dap with fake server', function()
           },
         },
       })
-    end
+    end)
     local captured_msg
     vim.notify = function(...)
       local msg = select(1, ...)

--- a/tests/run_server.lua
+++ b/tests/run_server.lua
@@ -1,0 +1,16 @@
+local server = require('tests.server')
+local opts = {
+  port = _G.DAP_PORT
+}
+io.stdout:setvbuf("no")
+io.stderr:setvbuf("no")
+local debug_adapter = server.spawn(opts)
+io.stderr:write("Listening on port=" .. debug_adapter.adapter.port .. "\n")
+local original_disconnect = debug_adapter.client.disconnect
+debug_adapter.client.disconnect = function(self, request)
+  original_disconnect(self, request)
+  os.exit(0)
+end
+vim.loop.run()
+vim.loop.walk(vim.loop.close)
+vim.loop.run()

--- a/tests/server.lua
+++ b/tests/server.lua
@@ -87,7 +87,8 @@ function Client:launch(request)
 end
 
 
-function M.spawn()
+function M.spawn(opts)
+  opts = opts or {}
   local server = uv.new_tcp()
   local host = '127.0.0.1'
   local spy = {
@@ -100,7 +101,7 @@ function M.spawn()
     spy.responses = {}
     spy.events = {}
   end
-  server:bind(host, 0)
+  server:bind(host, opts.port or 0)
   local client = {
     seq = 0,
     handlers = {},
@@ -112,7 +113,7 @@ function M.spawn()
     local socket = uv.new_tcp()
     client.socket = socket
     server:accept(socket)
-    socket:read_start(rpc.create_read_loop(vim.schedule_wrap(function(body)
+    socket:read_start(rpc.create_read_loop((function(body)
       client:handle_input(body)
     end)))
   end)

--- a/tests/server_executable_spec.lua
+++ b/tests/server_executable_spec.lua
@@ -1,0 +1,52 @@
+local dap = require('dap')
+
+describe('server executable', function()
+  after_each(function()
+    dap.terminate()
+    dap.close()
+    vim.wait(100, function()
+      return dap.session() == nil
+    end)
+  end)
+  it('Starts adapter executable and connects', function()
+    dap.adapters.dummy = {
+      type = 'server',
+      port = '${port}',
+      executable = {
+        command = vim.v.progpath,
+        args = {
+          '-Es',
+          '-u', 'NONE',
+          '--headless',
+          '-c', 'lua DAP_PORT=${port}',
+          '-c', 'luafile tests/run_server.lua'
+        },
+      }
+    }
+    local messages = {}
+    require('dap.repl').append = function(line)
+      local msg = line:gsub('port=%d+', 'port=12345')
+      table.insert(messages, msg)
+    end
+    dap.run({
+      type = 'dummy',
+      request = 'launch',
+      name = 'Launch',
+    })
+    vim.wait(2000, function()
+      local session = dap.session()
+      return (session and session.initialized)
+    end)
+    local session = dap.session()
+    assert.are_not.same(nil, session)
+    local expected_msg = "[debug-adapter stderr] Listening on port=12345\n"
+    assert.are.same({expected_msg}, messages)
+    assert.are.same(true, session.initialized, "initialized must be true")
+
+    dap.terminate()
+    vim.wait(100, function()
+      return dap.session() == nil
+    end)
+    assert.are.same(nil, dap.session())
+  end)
+end)


### PR DESCRIPTION
This makes the adapter definition for adapters that don't support STDIO
but only TCP a bit easier. For example, for delve it reduces the adapter
definition to:

```lua
  dap.adapters.delve = {
    type = 'server',
    port = '${port}',
    executable = {
      command = 'dlv',
      args = {'dap', '-l', '127.0.0.1:${port}'},
    }
  }
```
