### PR TITLE
fix(terminal): disable bd mapping until complete

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -235,6 +235,7 @@ local function run_in_terminal(self, request)
     terminal_height = terminal_win and api.nvim_win_get_height(terminal_win) or 40
   end
   api.nvim_buf_set_name(terminal_buf, '[dap-terminal] ' .. (self.config.name or body.args[1]))
+  pcall(api.nvim_buf_del_keymap, terminal_buf, "t", "<CR>")
   local ok, path = pcall(api.nvim_buf_get_option, cur_buf, 'path')
   if ok then
     api.nvim_buf_set_option(terminal_buf, 'path', path)


### PR DESCRIPTION
Pressing enter when inputting using the same terminal buffer will prematurely delete the buffer mid-session.

Related https://github.com/rcarriga/nvim-dap-ui/issues/120 