### PR TITLE
Add a `dap-type` buffer variable to terminal buffers with the `config.type` value

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -232,6 +232,7 @@ local function run_in_terminal(self, request)
       vim.wo[terminal_win].relativenumber = false
       vim.wo[terminal_win].signcolumn = "no"
     end
+    vim.b[terminal_buf]['dap-type'] = self.config.type
     terminal_width = terminal_win and api.nvim_win_get_width(terminal_win) or 80
     terminal_height = terminal_win and api.nvim_win_get_height(terminal_win) or 40
   end


### PR DESCRIPTION
This can be used by scripts or similar to process the terminal buffers
output depending on the config type. If a session ended, the information
is otherwise no longer available.

For example, one could parse the output of `python unittest` into the
quickfix list with something like this:

```lua
local efms = {
  python = [[%C %.%#,%A  File "%f"\, line %l%.%#,%Z%[%^ ]%\@=%m]],
}

function M.load()
  local buf = api.nvim_get_current_buf()
  local ft = vim.b[buf]['dap-type'] or vim.bo.filetype
  local efm = efms[ft] or vim.bo.errorformat or vim.g.errorformat
  local lines = api.nvim_buf_get_lines(buf, 0, -1, true)
  vim.fn.setqflist({}, 'r', { efm = efm, lines = lines })
end
```
