### PR TITLE
Set bufhidden=delete for preview window buffer

### DIFF
--- a/lua/dap/ui/widgets.lua
+++ b/lua/dap/ui/widgets.lua
@@ -432,6 +432,7 @@ function M.preview(expr)
       if vim.wo[win].previewwindow then
         local buf = api.nvim_win_get_buf(win)
         set_default_bufopts(buf)
+        vim.bo[buf].bufhidden = 'delete'
         return buf
       end
     end


### PR DESCRIPTION
Closing the preview window via `CTLR-w z` / `:pclose` shouldn't leave
stale buffers.
