### PR TITLE
Make session:request coroutine aware

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -661,7 +661,15 @@ function Session:_goto(line, source, col)
       utils.notify("No goto targets available. Can't execute goto", vim.log.levels.INFO)
       return
     end
-    local params = {threadId = self.stopped_thread_id, targetId = response.targets[1].id }
+    local target = ui().pick_if_many(
+      response.targets,
+      'goto target> ',
+      function(target) return target.label end
+    )
+    if not target then
+      return
+    end
+    local params = {threadId = self.stopped_thread_id, targetId = target.id }
     local thread = self.threads[self.stopped_thread_id]
     if thread then
       thread.stopped = false


### PR DESCRIPTION
If running within a coroutine the callback argument can now be omitted
to get the result as return value.

This can be utilized to avoid nesting via multiple callbacks if a method
requires multiple requests.