### PR TITLE
Schedule pick_one callback to ensure error messages are visible

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -1114,7 +1114,11 @@ function Session.spawn(_, adapter, opts)
   handle, pid_or_err = uv.spawn(adapter.command, spawn_opts, onexit)
   if not handle then
     onexit()
-    error('Error running ' .. adapter.command .. ': ' .. pid_or_err)
+    if adapter.command == "" then
+      error("adapter.command must not be empty. Got: " .. vim.inspect(adapter))
+    else
+      error('Error running ' .. adapter.command .. ': ' .. pid_or_err)
+    end
   end
   session.client = {
     write = function(line) stdin:write(line) end;

--- a/lua/dap/ui.lua
+++ b/lua/dap/ui.lua
@@ -62,19 +62,15 @@ function M.pick_one(items, prompt, label_fn, cb)
       end
     end
   end
-  -- vim.schedule ensures this method yields _before_ the coroutine.resume call happens
+  cb = vim.schedule_wrap(cb)
   if vim.ui then
-    vim.schedule(function()
-      vim.ui.select(items, {
-        prompt = prompt,
-        format_item = label_fn,
-      }, cb)
-    end)
+    vim.ui.select(items, {
+      prompt = prompt,
+      format_item = label_fn,
+    }, cb)
   else
     local result = M.pick_one_sync(items, prompt, label_fn)
-    vim.schedule(function()
-      cb(result)
-    end)
+    cb(result)
   end
   if co then
     return coroutine.yield()


### PR DESCRIPTION
Error messages reported by `error` or `assert` calls could go unnoticed
depending on the `vim.ui.select` implementation.

Scheduling the callback should avoid that.
