### PR TITLE
fix(sign): unplace debugPC sign on dap.close

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -987,6 +987,7 @@ function Session.connect(_, adapter, opts, on_connect)
       return
     end
     closed = true
+    vim.fn.sign_unplace(ns_pos)
     client:shutdown()
     client:close()
     session.threads = {}


### PR DESCRIPTION
The `DapStopped` sign is managed by the plugin and placed/unplaced on every `step` or `_jump`.

If the debugged application terminates by itself, it is properly cleaned up.

but if the user calls `require('dap').close()` or `require('dap').terminate()`, the sign is kept in place.

This PR adds a `vim.fn.sign_unplace` call to the `close` session function (which is called both for `close()` and for `terminate()` to properly clean up that sign.