### PR TITLE
useability: load project local configurations if available.

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -245,8 +245,20 @@ local function maybe_enrich_config_and_run(adapter, configuration, opts)
   end
 end
 
+local function load_project_config_if_exists()
+    for _, p in ipairs({"./.nvim-dap.lua", "./.nvim-dap/nvim-dap.lua"}) do
+        local f = io.open(p)
+        if f ~= nil then
+            f:close()
+            utils.notify(string.format("Loading project configuration: %s", p), vim.log.levels.INFO)
+            vim.cmd(":luafile " .. p)
+            return
+        end
+    end
+end
 
 local function select_config_and_run()
+  load_project_config_if_exists()
   local filetype = api.nvim_buf_get_option(0, 'filetype')
   local configurations = M.configurations[filetype] or {}
   assert(


### PR DESCRIPTION
Hey, 

At my day job we are configuring remote debugging for our code base. 

Currently, its very easy for us to just add a `launcher.json` file to the repository and everything "just work" when VSCode users open their editors the the source directory. 

Ideally, we'd like this to happen when using nvim-dap as well. 

I understand you can load a launcher.json but there are a few reasons I'm still suggestion loading a project-local nvim-dap.lua configuration. 

1) Loading a launcher.json still involves users creating and sourcing in a .lua configuration file, which some may not even know how to do (with runtime path and import rules etc...). 
2) I simply could not get the same `launcher.json` file we are checking, which works in vscode, to work with nvim-dap.
3) Neovim has an opinionated json decoder and I fear constatly removing trailing "," from config files may become an annoyance (this is not really a huge concern tho). 

This PR will search two directories for a nvim-dap config, "./.nvim-dap.lua" and "./.nvim-dap/nvim-dap.lua" and load them in that preference right before continuing on with the normal flow of the "DapContinue" command. 

The result is pretty nice, we can check in this file, and new neovim can run some `make` targets we have which launch our app in a remote debugger setting, and "DapContinue" just finds the config and connects to the remotes. 

Let me know if you'd be interesting in entertaining this idea. 

