### PR TITLE
user config aware sign define

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -380,12 +380,11 @@ nvim-dap uses five signs:
 - `DapBreakpointRejected` to indicate breakpoints rejected by the debug
   adapter (default: `R`)
 
-You can customize the signs by overriding their definitions after you've
-loaded `dap`. For example:
+You can customize the signs by setting them with the |sign_define()| function.
+For example:
 
 >
     lua << EOF
-    require('dap')
     vim.fn.sign_define('DapBreakpoint', {text='🛑', texthl='', linehl='', numhl=''})
     EOF
 <

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -154,13 +154,25 @@ M.adapters = {}
 ---@type table<string, Configuration[]>
 M.configurations = {}
 
+local signs = {
+  DapBreakpoint = { text = "B", texthl = "", linehl = "", numhl = "" },
+  DapBreakpointCondition = { text = "C", texthl = "", linehl = "", numhl = "" },
+  DapBreakpointRejected = { text = 'R', texthl = '', linehl = '', numhl = '' },
+  DapLogPoint = { text = 'L', texthl = '', linehl = '', numhl = '' },
+  DapStopped = { text = '→', texthl = '', linehl = 'debugPC', numhl = '' },
+}
 
-vim.fn.sign_define('DapBreakpoint', {text='B', texthl='', linehl='', numhl=''})
-vim.fn.sign_define("DapBreakpointCondition", { text = "C", texthl = "", linehl = "", numhl = "" })
-vim.fn.sign_define('DapBreakpointRejected', {text='R', texthl='', linehl='', numhl=''})
-vim.fn.sign_define('DapLogPoint', {text='L', texthl='', linehl='', numhl=''})
-vim.fn.sign_define('DapStopped', {text='→', texthl='', linehl='debugPC', numhl=''})
+local function sign_try_define(name)
+  local s = vim.fn.sign_getdefined(name)
+  if vim.tbl_isempty(s) then
+    local opts = signs[name]
+    vim.fn.sign_define(name, opts)
+  end
+end
 
+for name in pairs(signs) do
+  sign_try_define(name)
+end
 
 local function expand_config_variables(option)
   if type(option) == 'function' then


### PR DESCRIPTION
if a sign is already set in some user config we do not overwrite the value and skip it. This enables sign configuration by the user regardless where the user requires the dap plugin. This is kind related to the closed issue #76 