### PR TITLE
Expose `json_decode` for overrides in ext.vscode

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -280,8 +280,15 @@ debug adapters in Visual Studio Code.
 To load a `launch.json` file, use the `load_launchjs` function from the
 `dap.ext.vscode` module.
 
-Unlike VS Code, nvim-dap only supports standard JSON. Trailing commas on the
+Unlike VS Code, nvim-dap supports standard JSON. Trailing commas on the
 last item of a list are an error.
+
+If you install a 3rd-party json5 parser you can override the json decode
+function to support json5 features like trailing comma.
+>
+    require('dap.ext.vscode').json_decode = require'json5'.parse
+<
+(One json5 parser implementation is https://github.com/Joakker/lua-json5)
 
 
 load_launchjs({path}, {type_to_filetypes})        *dap.ext.vscode.load_launchjs*

--- a/lua/dap/ext/vscode.lua
+++ b/lua/dap/ext/vscode.lua
@@ -2,6 +2,8 @@ local dap = require('dap')
 local notify = require('dap.utils').notify
 local M = {}
 
+M.json_decode = vim.json and vim.json.decode or vim.fn.json_decode
+
 
 local function create_input(type_, input)
   if type_ == "promptString" then
@@ -102,8 +104,7 @@ end
 
 
 function M._load_json(jsonstr)
-  local decode = vim.json and vim.json.decode or vim.fn.json_decode
-  local data = decode(jsonstr)
+  local data = M.json_decode(jsonstr)
   local inputs = create_inputs(data.inputs or {})
   local has_inputs = next(inputs) ~= nil
 


### PR DESCRIPTION
Closes https://github.com/mfussenegger/nvim-dap/issues/650
