### PR TITLE
Breakpoints quickfix list smart replace.

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -511,7 +511,13 @@ end
 
 function M.list_breakpoints(open_quickfix)
   local qf_list = lazy.breakpoints.to_qf_list(lazy.breakpoints.get())
-  vim.fn.setqflist({}, 'r', {
+  local qflist = vim.fn.getqflist({ title = 1 })
+  action = 'a'
+  if qflist.title == DAP_QUICKFIX_TITLE then
+    action = 'r'
+  end
+
+  vim.fn.setqflist({}, action, {
     items = qf_list,
     context = DAP_QUICKFIX_CONTEXT,
     title = DAP_QUICKFIX_TITLE

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -511,9 +511,9 @@ end
 
 function M.list_breakpoints(open_quickfix)
   local qf_list = lazy.breakpoints.to_qf_list(lazy.breakpoints.get())
-  local qflist = vim.fn.getqflist({ title = 1 })
-  action = 'a'
-  if qflist.title == DAP_QUICKFIX_TITLE then
+  local current_qflist_title = vim.fn.getqflist({ title = 1 }).title
+  action = ' '
+  if current_qflist_title == DAP_QUICKFIX_TITLE then
     action = 'r'
   end
 


### PR DESCRIPTION
A list of breakpoints replaces the current quickfix list only if the current quickfix list is a list of breakpoints.  A quickfix list of breakpoints is recognized by the title.  If the title is the same as the title nvim-dap assigns then the list is counted as a quickfix list of breakpoints.  If the current quickfix list consists of something else like results from Telescope or make then the list is saved in the history and nvim-dap creates a new one.