### PR TITLE
Add templating support for launch.json and auto-load on save

### DIFF
--- a/lua/dap/ext/vscode.lua
+++ b/lua/dap/ext/vscode.lua
@@ -3,7 +3,7 @@ local notify = require('dap.utils').notify
 local M = {}
 
 M.json_decode = vim.json and vim.json.decode or vim.fn.json_decode
-
+M.type_to_filetypes = {}
 
 local function create_input(type_, input)
   if type_ == "promptString" then
@@ -122,7 +122,7 @@ end
 
 --- Extends dap.configurations with entries read from .vscode/launch.json
 function M.load_launchjs(path, type_to_filetypes)
-  type_to_filetypes = type_to_filetypes or {}
+  type_to_filetypes = vim.tbl_extend('keep', type_to_filetypes or {}, M.type_to_filetypes)
   local resolved_path = path or (vim.fn.getcwd() .. '/.vscode/launch.json')
   if not vim.loop.fs_stat(resolved_path) then
     return


### PR DESCRIPTION
This adds two autocmds.
The first one will pre-fill the content of a `.vscode/launch.json` file if it doesn't already exist to have the boilerplate ready.
The second one will automatically re-read the configurations from the `vscode/launch.json` if you modified it and are saving the changes.


This may be a bit controversial so I'll leave this open for a while and would appreciate feedback. (Use thumbs up/down, please leave comments if you have a strong opinion and rationale why it shouldn't be merged)

Alternatives:

- Add as cookbook entry to the Wiki
- Don't add the autocmds per default, but require opt-in via a `require('dap.ext.vscode').setup()`
