### PR TITLE
Fix incorrect cursor position when opening frame from dapui

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -383,20 +383,13 @@ function Session:_show_exception_info(thread_id)
 end
 
 
-local function with_win(win, fn, ...)
-  local args = {...}
-  local ok, err
-  api.nvim_win_call(win, function()
-    ok, err = pcall(fn, unpack(args))
-  end)
-  assert(ok, err)
-end
-
 
 local function set_cursor(win, line, column)
   local ok, err = pcall(api.nvim_win_set_cursor, win, { line, column - 1 })
   if ok then
-    with_win(win, api.nvim_command, 'normal! zv')
+    api.nvim_win_call(win, function()
+      api.nvim_command('normal! zv')
+    end)
   else
     local msg = string.format(
       "Debug adapter reported a frame at line %s column %s, but: %s. "

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -384,10 +384,11 @@ end
 
 
 local function with_win(win, fn, ...)
-  local cur_win = api.nvim_get_current_win()
-  api.nvim_set_current_win(win)
-  local ok, err = pcall(fn, ...)
-  pcall(api.nvim_set_current_win, cur_win)
+  local args = {...}
+  local ok, err
+  api.nvim_win_call(win, function()
+    ok, err = pcall(fn, unpack(args))
+  end)
   assert(ok, err)
 end
 


### PR DESCRIPTION
I noticed that sometimes when opening (jumping to) a stack frame in nvim-dap-ui the cursor position is incorrect. Using `nvim_win_call` instead of changing windows fixed the issue.