### PR TITLE
Fix REPL throwing an error when response result is empty

### DIFF
--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -157,8 +157,10 @@ local function evaluate_handler(err, resp)
       tree.render(layer, resp)
     end
   else
-    local lines = vim.split(resp.result, '\n', { trimempty = true })
-    layer.render(lines)
+    if resp.result then
+      local lines = vim.split(resp.result, '\n', { trimempty = true })
+      layer.render(lines)
+    end
   end
 end
 


### PR DESCRIPTION
The error is when the expression (or statement) in the REPL does not
have any return value, e.g., in a python adapter:

dap> print(2)      # evaluates to None
