### PR TITLE
Make the sign priority of DapBreakpoints higher than DapStopped

### DIFF
--- a/lua/dap/breakpoints.lua
+++ b/lua/dap/breakpoints.lua
@@ -48,7 +48,7 @@ function M.update(breakpoint)
           ns,
           get_sign_name(bp),
           bp.buf,
-          { lnum = bp.line; priority = 11; }
+          { lnum = bp.line; priority = 13; }
         )
       end
       bp.state.verified = breakpoint.verified
@@ -76,7 +76,7 @@ function M.set_state(bufnr, lnum, state)
         ns,
         'DapBreakpointRejected',
         bufnr,
-        { lnum = lnum; priority = 11; }
+        { lnum = lnum; priority = 13; }
       )
     end
   end
@@ -117,7 +117,7 @@ function M.toggle(opts, bufnr, lnum)
     ns,
     sign_name,
     bufnr,
-    { lnum = lnum; priority = 11; }
+    { lnum = lnum; priority = 13; }
   )
   if sign_id ~= -1 then
     bp_by_sign[sign_id] = bp

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -404,7 +404,14 @@ end
 
 
 local function jump_to_location(bufnr, line, column)
-  local ok, failure = pcall(vim.fn.sign_place, 0, ns_pos, 'DapStopped', bufnr, { lnum = line; priority = 12 })
+  local ok, failure = pcall(
+    vim.fn.sign_place,
+    0,
+    ns_pos,
+    'DapStopped',
+    bufnr,
+    { lnum = line; priority = 12; }
+  )
   if not ok then
     utils.notify(failure, vim.log.levels.ERROR)
   end


### PR DESCRIPTION
Previously, DapBreakpoints (as well as DapBreakpointRejected,
DapBreakpointCondition, etc.) had sign priority of 11
where DapStopped had 12. This means breakpoint signs on the line
where DAP is stopped at would be hidden.

This commit raises the priority of DapBreakpoint signs to 13,
higher than DapStopped so that the breakpoint sign can be visible
on stopped lines. Breakpoints would be more important because
DapStopped would usually have line highlights.
