### PR TITLE
Handle missing thread in auto_continue handling

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -562,10 +562,11 @@ function Session:event_stopped(stopped)
 
   local should_jump = stopped.reason ~= 'pause' or stopped.allThreadsStopped
   if self.stopped_thread_id and should_jump then
-    local thread = self.threads[self.stopped_thread_id]
     if defaults(self).auto_continue_if_many_stopped then
+      local thread = self.threads[self.stopped_thread_id]
+      local thread_name = thread and thread.name or self.stopped_thread_id
       log.debug(
-        'Received stopped event, but ' .. thread.name .. ' is already stopped. ' ..
+        'Received stopped event, but ' .. thread_name .. ' is already stopped. ' ..
         'Resuming newly stopped thread. ' ..
         'To disable this set the `auto_continue_if_many_stopped` option to false.')
       self:request('continue', { threadId = stopped.threadId })


### PR DESCRIPTION
There may not be a thread anymore for the `stopped_thread_id`.
That resulted in an error.

An alternative could be to reset the `stopped_thread_id` and assume it
is not stopped anymore, but not sure if that is safe.
