### PR TITLE
Show exception info on stopped via diagnostic

### DIFF
--- a/tests/server.lua
+++ b/tests/server.lua
@@ -27,6 +27,7 @@ function Client:send_err_response(request, message, error)
   table.insert(self.spy.responses, payload)
 end
 
+
 function Client:send_response(request, body)
   self.seq = request.seq + 1
   local payload = {


### PR DESCRIPTION
So far the exception info was shown in the REPL, but users may have the
REPL closed in which case they don't see the exception details.

This instead uses the diagnostic API to add the exception details as an
error.
