### PR TITLE
Adds mapping of paths between local and remotes

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -206,6 +206,15 @@ This is controlled via a `Configuration`, which has 3 required fields:
     name: string        -- A user-readable name for the configuration.
 <
 
+There is one optional field `remoteDirectoryMapping` that can be used when debugging remotely.
+If set, it will translate between local and remote paths. for example, when your workspace is at
+"/home/abc/work/app", but you are debugging in a container where the code is located at "/app",
+you can add this to the `Configuration`:
+
+>
+    remoteDirectoryMapping = { ["${workspaceFolder}"] = "/app", },
+<
+
 In addition, a `Configuration` accepts an arbitrary number of further options
 which are debug-adapter-specific.
 

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -815,6 +815,7 @@ do
         api.nvim_buf_attach(bufnr, false, { on_detach = remove_breakpoints })
       end
       local path = api.nvim_buf_get_name(bufnr)
+      path = utils.local_to_remote_path(path, self.config['remoteDirectoryMapping'])
       local payload = {
         source = {
           path = path;
@@ -908,6 +909,13 @@ end
 function Session:handle_body(body)
   local decoded = json_decode(body)
   log.debug(decoded)
+  if decoded and decoded.StackFrames then
+    for _, frame in ipairs(decoded.StackFrames) do
+      if frame.source and frame.source.path then
+        frame.source.path = utils.remote_to_local_path(path, self.config['remoteDirectoryMapping'])
+      end
+    end
+  end
   local listeners = dap().listeners
   if decoded.request_seq then
     local callback = self.message_callbacks[decoded.request_seq]

--- a/lua/dap/utils.lua
+++ b/lua/dap/utils.lua
@@ -128,5 +128,33 @@ function M.if_nil(x, default)
   return x == nil and default or x
 end
 
+function string.starts(String,Start)
+   return string.sub(String,1,string.len(Start))==Start
+end
+
+function M.local_to_remote_path(path, mapping)
+  if not mapping then return path end
+
+  for local_path, remote_path in pairs(mapping) do
+    if string.starts(path, local_path) then
+      return string.gsub(path, local_path, remote_path)
+    end
+  end
+
+  return path
+end
+
+function M.remote_to_local_path(path, mapping)
+  if not mapping then return path end
+
+  for local_path, remote_path in pairs(mapping) do
+    if string.starts(path, remote_path) then
+      return string.gsub(path, remote_path, local_path)
+    end
+  end
+
+  return path
+end
+
 
 return M


### PR DESCRIPTION
I develop my projects in docker containers, so using nvim-dap wasn't possible, because my local paths are always different from the paths in the containers. I added an optional parameter to dap configurations that allows to have a list of mappings from local to remote paths. It just replaces the start of paths that are sent from the key to the value of the mapping (if there is a match), and vice-verse for the responses from the dap server.

I'm sure there are more/other places where this translation would be needed (is setting breakpoints really the only point where a local path is sent to the server? 🤔), but it works well enough for me. It would be nice if someone who is more familiar with nvim-dap could turn this into a mergeable PR :)