### PR TITLE
Column breakpoint

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -620,13 +620,13 @@ attach({adapter}, {config})                                       *dap.attach()*
         |dap.continue()| or |dap.run()|
 
 
-set_breakpoint({condition}, {hit_condition}, {log_message})
+set_breakpoint({condition}, {hit_condition}, {log_message}, {column})
                                                           *dap.set_breakpoint()*
 
         Same as |toggle_breakpoint|, but is guaranteed to overwrite previous 
         breakpoint.
 
-toggle_breakpoint({condition}, {hit_condition}, {log_message})
+toggle_breakpoint({condition}, {hit_condition}, {log_message}, {column})
                                                        *dap.toggle_breakpoint()*
 
         Creates or removes a breakpoint at the current line.
@@ -640,6 +640,15 @@ toggle_breakpoint({condition}, {hit_condition}, {log_message})
             {log_message}   Optional log message. This transforms the breakpoint 
                             into a log point. Variable interpolation with {foo} is
                             supported within the message.
+            {column}        Optional column number. If set, then the
+                            breakpoint will be also set at the column.
+
+toggle_breakpoint_column({condition}, {hit_condition}, {log_message})
+                                                *dap.toggle_breakpoint_column()*
+
+        Same as |toggle_breakpoint|, but also takes into consideration the
+        column number.
+
 
 list_breakpoints()                                     *dap.list_breakpoints()*
 

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -577,16 +577,21 @@ function M.list_breakpoints(open_quickfix)
   end
 end
 
-function M.set_breakpoint(condition, hit_condition, log_message)
-  M.toggle_breakpoint(condition, hit_condition, log_message, true)
+function M.set_breakpoint(condition, hit_condition, log_message, column)
+  M.toggle_breakpoint(condition, hit_condition, log_message, column, true)
 end
 
-function M.toggle_breakpoint(condition, hit_condition, log_message, replace_old)
+function M.toggle_breakpoint_column(condition, hit_condition, log_message, replace_old)
+  M.toggle_breakpoint(condition, hit_condition, log_message, vim.fn.col('.'), replace_old)
+end
+
+function M.toggle_breakpoint(condition, hit_condition, log_message, column, replace_old)
   lazy.breakpoints.toggle({
     condition = condition,
     hit_condition = hit_condition,
     log_message = log_message,
-    replace = replace_old
+    replace = replace_old,
+    column = column,
   })
   if session and session.initialized then
     local bufnr = api.nvim_get_current_buf()

--- a/lua/dap/breakpoints.lua
+++ b/lua/dap/breakpoints.lua
@@ -109,7 +109,8 @@ function M.toggle(opts, bufnr, lnum)
     buf = bufnr,
     condition = opts.condition,
     logMessage = opts.log_message,
-    hitCondition = opts.hit_condition
+    hitCondition = opts.hit_condition,
+    column = opts.column,
   }
   local sign_name = get_sign_name(bp)
   local sign_id = vim.fn.sign_place(
@@ -147,6 +148,7 @@ function M.get(bufexpr)
       local bp_entry = bp_by_sign[bp.id] or {}
       table.insert(breakpoints, {
         line = bp.lnum;
+        column = bp_entry.column;
         condition = bp_entry.condition;
         hitCondition = bp_entry.hitCondition;
         logMessage = bp_entry.logMessage;
@@ -194,5 +196,8 @@ do
   end
 end
 
+function M.tmp()
+  return bp_by_sign
+end
 
 return M

--- a/plugin/dap.lua
+++ b/plugin/dap.lua
@@ -19,6 +19,7 @@ cmd('DapSetLogLevel',
 cmd('DapShowLog', 'split | e ' .. vim.fn.stdpath('cache') .. '/dap.log | normal! G', {})
 cmd('DapContinue', function() require('dap').continue() end, { nargs = 0 })
 cmd('DapToggleBreakpoint', function() require('dap').toggle_breakpoint() end, { nargs = 0 })
+cmd('DapToggleBreakpointColumn', function() require('dap').toggle_breakpoint_column() end, { nargs = 0 })
 cmd('DapToggleRepl', function() require('dap.repl').toggle() end, { nargs = 0 })
 cmd('DapStepOver', function() require('dap').step_over() end, { nargs = 0 })
 cmd('DapStepInto', function() require('dap').step_into() end, { nargs = 0 })


### PR DESCRIPTION
This PR adds the possibility to also set the column when toggling or setting a breakpoing. 

For example, given this code:

```typescript
const arr = [{name: 'Name 1', id: 1}, {name: 'Name 2', id: 2}];
console.log(arr.map(x => x.id));
```

If I go on the second line and I call `lua require('dap').toggle_breakpoint()`, this would set the breakpoint before logging. This means that the program would stop only once, before the console log, without giving me the possibility to stop and to debug also what happens inside the mapping.

This PR adds the `toggle_breakpoint_column`, with the same parameters as `toggle_breakpoint`. 

So, for example, I could go with the cursor on the `x` from `x.id` (line 2, column 26) and call `lua require('dap').toggle_breakpoint_column()`. This would set the breakpoint inside the `arr.map`. This means that it would stop for each value of the array, and I could debug each value of the array. 
