### PR TITLE
Support command:pickRemoteProcess

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -274,6 +274,7 @@ Things to note:
   - `${workspaceFolder}`: The current working directory of Neovim
   - `${workspaceFolderBasename}`: The name of the folder opened in Neovim
   - `${command:pickProcess}`: Open dialog to pick process using |vim.ui.select|
+  - `${command:pickRemoteProcess}`: Open dialog to pick a remote process using |vim.ui.select|
   - `${env:Name}`: Environment variable named `Name`, for example: `${env:HOME}`.
 
 ==============================================================================


### PR DESCRIPTION
## Functionality
The little documented `pickRemoteProcess` command can be used with the `pipeTransport` option to query processes running on a potentially remote host rather than the local machine.

This effectively works by running the command to list processes in the same environment that the debugger will be run in.

See https://code.visualstudio.com/docs/cpp/pipe-transport for details.

## Implementation

In order to pick a remote process it's necessary to know the rest of the `pipeTransport` configuration. This is currently achieved by passing the un-expanded configuration to the `expand_config_variables` function and each of the functions in `var_placeholders_once`. I'm not sure if there's a better way of doing this that would allow placeholders within the `pipeTransport` configuration to be used.

## Reproduction

An example config might look like:
```json
    {
      "name": "C++ Attach in hello_gdb container",
      "type": "cppdbg",
      "request": "attach",
      "program": "/hello.out",
      "processId": "${command:pickRemoteProcess}",
      "pipeTransport": {
          "pipeCwd": "${workspaceRoot}",
          "pipeProgram": "docker",
          "pipeArgs": [
              "exec", 
              "-i", 
              "hello_gdb", 
              "sh",
              "-c"
          ],
          "debuggerPath": "/usr/bin/gdb"
      },
      "sourceFileMap": {
              "/src":"${workspaceRoot}"
      },
      "linux": {
        "MIMode": "gdb"
      },
      "setupCommands": [
        {
          "description": "Enable pretty-printing for gdb",
          "text": "-enable-pretty-printing",
          "ignoreFailures": true
        }
      ]
    }
```
This is adapted from `launch.json` in https://github.com/andyneff/hello-world-gdb which also has a docker container that can be used to test the functionality.