### PR TITLE
fix: invalid buffer is on diagnostic reset

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -1395,8 +1395,8 @@ function Session:close()
     self.handlers.after()
     self.handlers.after = nil
   end
-  self.client.close()
   vim.diagnostic.reset(ns)
+  self.client.close()
 end
 
 


### PR DESCRIPTION
Continually run into the following error when restarting a debugging session:

```
Error executing vim.schedule lua callback: /usr/share/nvim/runtime/lua/vim/diagnostic.lua:1458: Invalid buffer id: 22
stack traceback:
        [C]: in function 'nvim_exec_autocmds'
        /usr/share/nvim/runtime/lua/vim/diagnostic.lua:1458: in function 'reset'
        /home/louis/.config/nvim/after/nvim-dap/lua/dap/session.lua:1399: in function 'close'
        /home/louis/.config/nvim/after/nvim-dap/lua/dap/session.lua:703: in function 'callback'
        /home/louis/.config/nvim/after/nvim-dap/lua/dap/session.lua:958: in function </home/louis/.config/nvim/after/nvim-dap/lua/dap/session.lua:950>
```

Swapping the session close and the reset of the namespace in session.lua seems to fix the issue.

Signed-off-by: Louis DeLosSantos <louis.delos@gmail.com>