### PR TITLE
feat(session): pass request seq to callbacks/listeners

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -1030,12 +1030,13 @@ For example:
 Listeners registered in the `before` table are called *before* the internal `nvim-dap` handlers are called. The listeners registered in the `after` table are called *after* internal `nvim-dap` handlers.
 
 
-For commands (request responses), the listeners are called with four arguments:
+For commands (request responses), the listeners are called with five arguments:
 
 1. The session
 2. An error: A optional table with `message` and `body` properties.
 3. A table with the response. `nil` if an error occurred.
 4. The original payload of the request
+5. The sequence number for the request (also known as message ID)
 
 For events, the listeners are called with two arguments:
 

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -935,22 +935,22 @@ function Session:handle_body(body)
     if decoded.success then
       vim.schedule(function()
         for _, c in pairs(listeners.before[decoded.command]) do
-          c(self, nil, decoded.body, request)
+          c(self, nil, decoded.body, request, decoded.request_seq)
         end
-        callback(nil, decoded.body)
+        callback(nil, decoded.body, decoded.request_seq)
         for _, c in pairs(listeners.after[decoded.command]) do
-          c(self, nil, decoded.body, request)
+          c(self, nil, decoded.body, request, decoded.request_seq)
         end
       end)
     else
       vim.schedule(function()
         local err = { message = decoded.message; body = decoded.body; }
         for _, c in pairs(listeners.before[decoded.command]) do
-          c(self, err, nil, request)
+          c(self, err, nil, request, decoded.request_seq)
         end
-        callback(err, nil)
+        callback(err, nil, decoded.request_seq)
         for _, c in pairs(listeners.after[decoded.command]) do
-          c(self, err, nil, request)
+          c(self, err, nil, request, decoded.request_seq)
         end
       end)
     end


### PR DESCRIPTION
Allows users to distinguish between their own requests and other requests when listening.

The motiviation for this is that nvim-dap maintains some state internally for its functionality (e.g. session.current_frame) which nvim-dap-ui needs to be aware of so users don't have issues with the two plugins showing different information. Some of this state is set after requests such as `stackTrace` for the current frame. nvim-dap-ui needs to listen for this and refresh after it has been processed. Issues arise when the listener causes more stack trace requests, leading to infinite recursive calls because the listener can't distinguish between calls made by nvim-dap and itself.

This is occurring now because of a large refactor of nvim-dap-ui which moves away from maintaining state (which previously used the nvim-dap request result) to making direct calls to the debugging adapter for all data.

For reference here is how I am using this change 
https://github.com/rcarriga/nvim-dap-ui/pull/193/files#diff-d72688c95f8375fabf516ae99d7dc57b58ac3e65f64f5678af05411de83206f9R100-R103
https://github.com/rcarriga/nvim-dap-ui/pull/193/files#diff-d72688c95f8375fabf516ae99d7dc57b58ac3e65f64f5678af05411de83206f9R153-R155