### PR TITLE
feat(switchbuf): use setting instead of variable

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -608,7 +608,7 @@ local function jump_to_frame(session, frame, preserve_focus_hint, stopped)
     return
   end
   vim.fn.bufload(bufnr)
-  local switchbuf = defaults(session).switchbuf or vim.g.switchbuf or 'uselast'
+  local switchbuf = defaults(session).switchbuf or vim.o.switchbuf or 'uselast'
   jump_to_location(bufnr, frame.line, frame.column, switchbuf, session.filetype)
   if stopped and stopped.reason == 'exception' then
     session:_show_exception_info(stopped.threadId, bufnr, frame)


### PR DESCRIPTION
following up from #803, @mfussenegger do you think we can use the standard setting instead of a global variable?