### PR TITLE
fix(switchbuf): use uselast if no buffer found

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -550,10 +550,7 @@ local function jump_to_location(bufnr, line, column, switchbuf, filetype)
       return
     end
   end
-  utils.notify(
-    'Stopped at line ' .. line .. ' but `switchbuf` setting prevented jump to location. Target buffer ' .. bufnr .. ' not open in any window?',
-    vim.log.levels.WARN
-  )
+  switchbuf_fn.uselast()
 end
 
 


### PR DESCRIPTION
This is at least my understanding that in core if you have `switchbuf = usetab` and the buffer is not visible `uselast` is used instead.