### PR TITLE
Add namespace pool and use per-session namespace for signs/diagnostic

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -874,9 +874,6 @@ end
 
 ---@param s Session|nil
 function M.set_session(s)
-  if not s then
-    pcall(vim.fn.sign_unplace, 'dap_pos')
-  end
   session = s
 end
 


### PR DESCRIPTION
In preparation for multiple/hiearhical sessions which will be required
for the `startDebugging` reverse request.

With a global namespace we'd clear signs and diagnostics of all sessions
if one exits. That's a problem.
