### PR TITLE
Increase chance to trigger request callbacks on debug adapter exit

### DIFF
--- a/lua/dap/breakpoints.lua
+++ b/lua/dap/breakpoints.lua
@@ -60,7 +60,10 @@ end
 
 
 function M.set_state(bufnr, lnum, state)
-  local placements = vim.fn.sign_getplaced(bufnr, { group = ns; lnum = lnum; })
+  local ok, placements = pcall(vim.fn.sign_getplaced, bufnr, { group = ns; lnum = lnum; })
+  if not ok then
+    return
+  end
   local signs = placements[1].signs
   if not signs or next(signs) == nil then
     return


### PR DESCRIPTION
If the client sends a terminate the debug adapter can send the response,
terminate event and terminate the debug adapter process. In that case
the client immediately closed the stdout handle and cleared the message
callbacks table, preventing it from reliably processing the last few
messages.

This makes use of the async stdout:shutdown/client:shutdown to give it a
chance to process these last messages.

This is a follow up to
https://github.com/mfussenegger/nvim-dap/commit/03807a4682081cc2523219ef17a36a618995b36d
and should ensure that event_terminated listeners triggers happen in
most (all?) cases.
