### PR TITLE
Add supportsProgressReporting capability

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -44,9 +44,9 @@ M.repl = setmetatable({}, {
 ---@field event_module table<string, fun(session: Session, body: any)>
 ---@field event_output table<string, fun(session: Session, body: any)>
 ---@field event_process table<string, fun(session: Session, body: any)>
----@field event_progressEnd table<string, fun(session: Session, body: any)>
----@field event_progressStart table<string, fun(session: Session, body: any)>
----@field event_progressUpdate table<string, fun(session: Session, body: any)>
+---@field event_progressEnd table<string, fun(session: Session, body: dap.ProgressEndEvent)>
+---@field event_progressStart table<string, fun(session: Session, body: dap.ProgressStartEvent)>
+---@field event_progressUpdate table<string, fun(session: Session, body: dap.ProgressUpdateEvent)>
 ---@field event_stopped table<string, fun(session: Session, body: dap.StoppedEvent)>
 ---@field event_terminated table<string, fun(session: Session, body: dap.TerminatedEvent)>
 ---@field event_thread table<string, fun(session: Session, body: any)>

--- a/lua/dap/protocol.lua
+++ b/lua/dap/protocol.lua
@@ -114,3 +114,21 @@
 
 ---@class dap.TerminatedEvent
 ---@field restart? any
+
+
+---@class dap.ProgressStartEvent
+---@field progressId string
+---@field title string
+---@field requestId? number
+---@field cancellable? boolean
+---@field message? string
+---@field percentage? number
+
+---@class dap.ProgressUpdateEvent
+---@field progressId string
+---@field message? string
+---@field percentage? number
+
+---@class dap.ProgressEndEvent
+---@field progressId string
+---@field message? string

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -1502,6 +1502,7 @@ function Session:initialize(config)
     linesStartAt1 = true;
     supportsRunInTerminalRequest = true;
     supportsVariableType = true;
+    supportsProgressReporting = true;
     locale = os.getenv('LANG') or 'en_US';
   }, function(err0, result)
     if err0 then
@@ -1659,5 +1660,32 @@ end
 function Session:event_capabilities(body)
   self.capabilities = vim.tbl_extend('force', self.capabilities, body.capabilities)
 end
+
+
+---@param body dap.ProgressStartEvent
+function Session.event_progressStart(_, body)
+  if body.message then
+    progress.report(body.title .. ': ' .. body.message)
+  else
+    progress.report(body.title)
+  end
+end
+
+---@param body dap.ProgressUpdateEvent
+function Session.event_progressUpdate(_, body)
+  if body.message then
+    progress.report(body.message)
+  end
+end
+
+---@param body dap.ProgressEndEvent
+function Session:event_progressEnd(body)
+  if body.message then
+    progress.report(body.message)
+  else
+    progress.report('Running: ' .. (self.config.name or '[No Name]'))
+  end
+end
+
 
 return Session


### PR DESCRIPTION
Not sure which debug adapters make use of this.
Basic implementation that shows title and message in the `status()`
function.

This will also allow extensions to subscribe to the events and display
the information in more sophisticated ways.
