### PR TITLE
#833 - add Lua style example mappings to help

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -462,8 +462,7 @@ MAPPINGS                                             *dap-mappings*
 
 nvim-dap does not configure any mappings by default.
 
-Some example mappings you could configure:
-
+Some example mappings you could configure, first in traditional VimL, then Lua:
 >vim
     nnoremap <silent> <F5> <Cmd>lua require'dap'.continue()<CR>
     nnoremap <silent> <F10> <Cmd>lua require'dap'.step_over()<CR>
@@ -475,6 +474,19 @@ Some example mappings you could configure:
     nnoremap <silent> <Leader>dr <Cmd>lua require'dap'.repl.open()<CR>
     nnoremap <silent> <Leader>dl <Cmd>lua require'dap'.run_last()<CR>
 <
+>lua
+    vim.keymap.set('n','<F5>',function() require('dap').continue() end)
+    vim.keymap.set('n','<F10>',function() require('dap').step_over() end)
+    vim.keymap.set('n','<F11>',function() require('dap').step_into() end)
+    vim.keymap.set('n','<F12>',function() require('dap').step_out() end)
+    vim.keymap.set('n','<Leader>b',function() require('dap').toggle_breakpoint() end)
+    vim.keymap.set('n','<Leader>B',function() require('dap').set_breakpoint() end)
+    vim.keymap.set('n','<Leader>lp',function() require('dap').set_breakpoint(nil, nil, vim.fn.input('Log point message: ')) end)
+    vim.keymap.set('n','<Leader>dr',function() require('dap').repl.open() end)
+    vim.keymap.set('n','<Leader>dl',function() require('dap').run_last() end)
+<
+
+
 
 ==============================================================================
 CLIENT CONFIGURATION                                             *dap.defaults*

--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -462,18 +462,7 @@ MAPPINGS                                             *dap-mappings*
 
 nvim-dap does not configure any mappings by default.
 
-Some example mappings you could configure, first in traditional VimL, then Lua:
->vim
-    nnoremap <silent> <F5> <Cmd>lua require'dap'.continue()<CR>
-    nnoremap <silent> <F10> <Cmd>lua require'dap'.step_over()<CR>
-    nnoremap <silent> <F11> <Cmd>lua require'dap'.step_into()<CR>
-    nnoremap <silent> <F12> <Cmd>lua require'dap'.step_out()<CR>
-    nnoremap <silent> <Leader>b <Cmd>lua require'dap'.toggle_breakpoint()<CR>
-    nnoremap <silent> <Leader>B <Cmd>lua require'dap'.set_breakpoint(vim.fn.input('Breakpoint condition: '))<CR>
-    nnoremap <silent> <Leader>lp <Cmd>lua require'dap'.set_breakpoint(nil, nil, vim.fn.input('Log point message: '))<CR>
-    nnoremap <silent> <Leader>dr <Cmd>lua require'dap'.repl.open()<CR>
-    nnoremap <silent> <Leader>dl <Cmd>lua require'dap'.run_last()<CR>
-<
+Some example mappings you could configure:
 >lua
     vim.keymap.set('n','<F5>',function() require('dap').continue() end)
     vim.keymap.set('n','<F10>',function() require('dap').step_over() end)


### PR DESCRIPTION
As someone very new to NeoVim, I was getting started using [kickstart.nvim](https://github.com/nvim-lua/kickstart.nvim).

As that is a Lua based init script, I couldn't understand how to adapt the VimL nnoremap commands presented in :help mappings into their Lua alternatives. Thankfully in aYoutube video I stumbled into the vim.keymap.set() syntax, but I think presenting both would help new folks out a lot.

Thanks for the amazing plugin!