### PR TITLE
Allow underscore in id of `${input:<id>}`

### DIFF
--- a/lua/dap/ext/vscode.lua
+++ b/lua/dap/ext/vscode.lua
@@ -71,7 +71,7 @@ local function apply_input(inputs, value)
   if type(value) ~= "string" then
     return value
   end
-  local matches = string.gmatch(value, "${input:(%w+)}")
+  local matches = string.gmatch(value, "${input:([%w_]+)}")
   local input_functions = {}
   for input_id in matches do
     local input_key = "${input:" .. input_id .. "}"

--- a/tests/ext_vscode_spec.lua
+++ b/tests/ext_vscode_spec.lua
@@ -65,12 +65,12 @@ describe('dap.ext.vscode', function()
             "type": "dummy",
             "request": "launch",
             "name": "Dummy",
-            "program": "${workspaceFolder}/${input:myInput}"
+            "program": "${workspaceFolder}/${input:my_input}"
           }
         ],
         "inputs": [
           {
-            "id": "myInput",
+            "id": "my_input",
             "type": "pickString",
             "options": ["one", "two", "three"],
             "description": "Select input"


### PR DESCRIPTION
Fixes https://github.com/mfussenegger/nvim-dap/issues/837
