### PR TITLE
feat(repl): set buflisted=false

### DIFF
--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -25,6 +25,7 @@ local function new_buf()
   api.nvim_buf_set_option(buf, 'buftype', 'prompt')
   api.nvim_buf_set_option(buf, 'filetype', 'dap-repl')
   api.nvim_buf_set_option(buf, 'omnifunc', "v:lua.require'dap.repl'.omnifunc")
+  api.nvim_buf_set_option(buf, 'buflisted', false)
   local ok, path = pcall(api.nvim_buf_get_option, prev_buf, 'path')
   if ok then
     api.nvim_buf_set_option(buf, 'path', path)


### PR DESCRIPTION
Any objections to setting the REPL to unlisted? It's a common issue for nvim-dap-ui but I'd rather avoid messing with the buffer if possible.
https://github.com/rcarriga/nvim-dap-ui/issues/214
https://github.com/rcarriga/nvim-dap-ui/commit/b3b977095877e8acc1ff236cffc81b5331619493#commitcomment-98160282
https://github.com/rcarriga/nvim-dap-ui/issues/165
https://github.com/rcarriga/nvim-dap-ui/issues/130