### PR TITLE
Add support for running concurrent debug sessions

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -615,7 +615,7 @@ continue()                                                      *dap.continue()*
         application.
 
 
-run({config})                                                        *dap.run()*
+run({config}, {opts})                                                *dap.run()*
         Looks up a debug adapter entry for the given configuration and runs it.
         This is implicitly called by |dap.continue()| if no debug session is
         active.
@@ -625,8 +625,13 @@ run({config})                                                        *dap.run()*
         create configurations dynamically, for example to debug individual test
         cases.
 
+        If a debug session with the same name is already active, it will
+        restart the session.
+
         Parameters:
             {config}  |dap-configuration| to run
+            {opts}    Optional table with:
+                      - `new: boolean` to force running an additional debug session
 
 
 run_last()                                                      *dap.run_last()*
@@ -919,8 +924,12 @@ set_log_level(level)                                       *dap.set_log_level()*
 
 
 session()                                                        *dap.session()*
-        Returns the current session or nil if no session exists.
+        Returns the currently focused session or nil if no session exists or
+        has focus.
 
+sessions()                                                      *dap.sessions()*
+        Returns a table with the active top-level debug sessions.
+        The keys are session ids and the values are the `Session` instances.
 
 status()
         Returns the status of the current debug session as text
@@ -1030,6 +1039,7 @@ The widgets may have the following custom mappings enabled:
 
 Available widgets entities:
 
+- sessions
 - scopes
 - frames
 - expression

--- a/lua/dap/progress.lua
+++ b/lua/dap/progress.lua
@@ -22,7 +22,14 @@ function M.report(msg)
   if idx_write == idx_read then
     idx_read = (idx_read + 1) % max_size
   end
-  vim.cmd('doautocmd <nomodeline> User DapProgressUpdate')
+
+  if vim.in_fast_event() then
+    vim.schedule(function()
+      vim.cmd('doautocmd <nomodeline> User DapProgressUpdate')
+    end)
+  else
+    vim.cmd('doautocmd <nomodeline> User DapProgressUpdate')
+  end
 end
 
 

--- a/lua/dap/ui.lua
+++ b/lua/dap/ui.lua
@@ -419,7 +419,7 @@ end
 ---@class dap.ui.LineInfo
 ---@field mark_id number
 ---@field item any
----@field context table
+---@field context table|nil
 
 ---@return dap.ui.Layer
 function M.layer(buf)
@@ -456,7 +456,7 @@ function M.layer(buf)
     ---@generic T
     ---@param xs T[]
     ---@param render_fn fun(T):string
-    ---@param context table
+    ---@param context table|nil
     ---@param start nil|number 0-indexed
     ---@param end_ nil|number 0-indexed exclusive
     render = function(xs, render_fn, context, start, end_)

--- a/lua/dap/ui/widgets.lua
+++ b/lua/dap/ui/widgets.lua
@@ -251,6 +251,46 @@ M.frames = {
 }
 
 
+M.sessions = {
+  refresh_listener = {'event_initialized', 'event_terminated', 'disconnected'},
+  new_buf = function()
+    local buf = new_buf()
+    api.nvim_buf_set_name(buf, 'dap-sessions-' .. tostring(buf))
+    return buf
+  end,
+  render = function(view)
+    local dap = require('dap')
+    local sessions = dap.sessions()
+    local layer = view.layer()
+    local context = {}
+    context.actions = {
+      {
+        label = "Focus session",
+        fn = function(_, s)
+          if s then
+            dap.set_session(s)
+            view.refresh()
+          end
+          if vim.bo.bufhidden == 'wipe' then
+            view.close()
+          end
+        end
+      }
+    }
+    local render_session = function(s)
+      local focused = dap.session()
+      local text = s.id .. ': ' .. s.config.name
+      if s.id == focused.id then
+        return '→ ' .. text
+      else
+        return '  ' .. text
+      end
+    end
+    layer.render(vim.tbl_values(sessions), render_session, context)
+  end,
+}
+
+
 M.expression = {
   new_buf = new_buf,
   before_open = function(view)

--- a/tests/server.lua
+++ b/tests/server.lua
@@ -1,8 +1,8 @@
 local uv = vim.loop
 local rpc = require('dap.rpc')
 
-local json_decode = vim.json and vim.json.decode or vim.fn.json_decode
-local json_encode = vim.json and vim.json.encode or vim.fn.json_encode
+local json_decode = vim.json.decode
+local json_encode = vim.json.encode
 
 local M = {}
 local Client = {}

--- a/tests/sessions_spec.lua
+++ b/tests/sessions_spec.lua
@@ -1,0 +1,65 @@
+local dap = require('dap')
+
+
+local function wait(predicate, msg)
+  vim.wait(1000, predicate)
+  local result = predicate()
+  assert.are_not.same(false, result, msg and vim.inspect(msg()) or nil)
+  assert.are_not.same(nil, result)
+end
+
+
+local function run_and_wait_until_initialized(conf, server)
+  dap.run(conf)
+  wait(function()
+    local session = dap.session()
+    -- wait for initialize and launch requests
+    return (session and session.initialized and #server.spy.requests == 2)
+  end)
+  return dap.session()
+end
+
+
+describe('sessions', function()
+  local srv1
+  local srv2
+
+  before_each(function()
+    srv1 = require('tests.server').spawn()
+    srv2 = require('tests.server').spawn()
+    dap.adapters.dummy1 = srv1.adapter
+    dap.adapters.dummy2 = srv2.adapter
+  end)
+  after_each(function()
+    srv1.stop()
+    srv2.stop()
+    dap.terminate()
+    dap.terminate()
+  end)
+  it('can run multiple sessions', function()
+    local conf1 = {
+      type = 'dummy1',
+      request = 'launch',
+      name = 'Launch file 1',
+    }
+    local conf2 = {
+      type = 'dummy2',
+      request = 'launch',
+      name = 'Launch file 2',
+    }
+    local s1 = run_and_wait_until_initialized(conf1, srv1)
+    local s2 = run_and_wait_until_initialized(conf2, srv2)
+    assert.are.same(2, #dap.sessions())
+    assert.are.not_same(s1.id, s2.id)
+
+    dap.terminate()
+    wait(function() return #dap.sessions() == 1 end, function() return dap.sessions() end)
+    assert.are.same(true, s2.closed)
+    assert.are.same(false, s1.closed)
+    assert.are.same(s1, dap.session())
+
+    dap.terminate()
+    wait(function() return #dap.sessions() == 0 end, function() return dap.sessions() end)
+    assert.are.same(nil, dap.session())
+  end)
+end)


### PR DESCRIPTION
~~Still needs some work~~

New API:

- `dap.sessions()` to return active debug sessions
- `dap.ui.widgets.sessions` to show active debug sessions

Step functions will change the focus automatically if the currently
focused session is not stopped.
This should make common scenarios like debugging client + server where
you step from making requests on the client to receiving request on the
server convenient.

Note that this is unrelated to `startDebugging` support. The PR here is
about concurrent top-level sessions. `startDebugging` support will
introduce hierarchical sessions. (Probably including something like
`children` in the `Session` object)

## Open questions

- ~~If there is an active session, should `run_last` / `run` default to restart (terminate, run new), or should they default to run an additional session?~~ Will restart if config name matches, otherwise start  additional session


https://user-images.githubusercontent.com/38700/215311877-f07788e5-348b-4d6c-aaea-188005cff981.mp4

