### PR TITLE
Add support for LuaRocks + release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: "release"
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v2.0.0
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          detailed_description: |
+            nvim-dap allows you to:
+
+            * Launch an application to debug
+            * Attach to running applications and debug them
+            * Set breakpoints and step through code
+            * Inspect the state of the application
+          copy_directories:
+            doc
+            plugin

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 ## Installation
 
+[![LuaRocks](https://img.shields.io/luarocks/v/mfussenegger/nvim-dap?logo=lua&color=purple)](https://luarocks.org/modules/mfussenegger/nvim-dap)
+
 - Install nvim-dap like any other Neovim plugin:
   - `git clone https://github.com/mfussenegger/nvim-dap.git ~/.config/nvim/pack/plugins/start/nvim-dap`
   - Or with [vim-plug][11]: `Plug 'mfussenegger/nvim-dap'`

--- a/nvim-dap-scm-1.rockspec
+++ b/nvim-dap-scm-1.rockspec
@@ -1,0 +1,40 @@
+local _MODREV, _SPECREV = 'scm', '-1'
+rockspec_format = "3.0"
+package = 'nvim-dap'
+version = _MODREV .. _SPECREV
+
+description = {
+  summary = 'Debug Adapter Protocol client implementation for Neovim.',
+  detailed = [[
+  nvim-dap allows you to:
+
+  * Launch an application to debug
+  * Attach to running applications and debug them
+  * Set breakpoints and step through code
+  * Inspect the state of the application
+  ]],
+  labels = {
+    'neovim',
+    'plugin',
+    'debug-adapter-protocol',
+    'debugger',
+  },
+  homepage = 'https://github.com/mfussenegger/nvim-dap',
+  license = 'GPL-3.0',
+}
+
+dependencies = {
+  'lua >= 5.1, < 5.4',
+}
+
+source = {
+   url = 'git://github.com/mfussenegger/nvim-dap',
+}
+
+build = {
+   type = 'builtin',
+   copy_directories = {
+     'doc',
+     'plugin',
+   },
+}


### PR DESCRIPTION
nvim-dap is a common dependency across Neovim plugins. Using luarocks may alleviate the need for users to specify their plugins' dependencies in their plugin manager (e.g., vim-plug or packer).
See also [this blog post](https://teto.github.io/posts/2021-09-17-neovim-plugin-luarocks.html) for details.

This PR adds a release workflow that publishes this plugin to [LuaRocks](https://luarocks.org/) whenever a tag is pushed, as well as a rockspec that can be used to release to the `dev` channel or install this plugin from source using the luarocks CLI.

For the release workflow to work, someone with a LuaRocks account will have to add their API key to this repo's secrets.

Note that I have added a shield to the readme that assumes the existence of an `mfussenegger/nvim-dap` LuaRocks module.