### PR TITLE
Don't add extra newlines to REPL on output events

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -850,7 +850,7 @@ function M.run_to_cursor()
 end
 
 
----@param opts table<string, any>
+---@param opts? table<string, any>
 function M.continue(opts)
   if not session then
     session = first_stopped_session()

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -710,7 +710,7 @@ function Session.event_output(_, body)
   if body.category == 'telemetry' then
     log.info('Telemetry', body.output)
   else
-    repl.append(body.output, '$')
+    repl.append(body.output, '$', { newline = false })
   end
 end
 

--- a/lua/dap/ui.lua
+++ b/lua/dap/ui.lua
@@ -455,7 +455,7 @@ function M.layer(buf)
     ---
     ---@generic T
     ---@param xs T[]
-    ---@param render_fn fun(T):string
+    ---@param render_fn? fun(T):string
     ---@param context table|nil
     ---@param start nil|number 0-indexed
     ---@param end_ nil|number 0-indexed exclusive

--- a/tests/repl_spec.lua
+++ b/tests/repl_spec.lua
@@ -1,0 +1,14 @@
+local api = vim.api
+
+describe('dap.repl', function()
+  it("append doesn't add newline with newline = false", function()
+    local repl = require('dap.repl')
+    local buf = repl.open()
+    repl.append('foo', nil, { newline = false })
+    repl.append('bar', nil, { newline = false })
+    repl.append('\nbaz\n', nil, { newline = false })
+
+    local lines = api.nvim_buf_get_lines(buf, 0, -1, true)
+    assert.are.same({'foobar', 'baz', ''}, lines)
+  end)
+end)


### PR DESCRIPTION
Closes https://github.com/mfussenegger/nvim-dap/issues/845 and https://github.com/mfussenegger/nvim-dap/issues/854
