### PR TITLE
Fix listing breakpoints with go/delve

### DIFF
--- a/lua/dap/breakpoints.lua
+++ b/lua/dap/breakpoints.lua
@@ -180,9 +180,9 @@ do
         local text_parts = {
           unpack(api.nvim_buf_get_lines(bufnr, bp.line - 1, bp.line, false), 1),
           state.verified == false and (state.message and 'Rejected: ' .. state.message or 'Rejected') or nil,
-          non_empty(bp.logMessage) and "Log message: " .. bp.logMessage,
-          non_empty(bp.condition) and "Condition: " .. bp.condition,
-          non_empty(bp.hitCondition) and "Hit condition: " .. bp.hitCondition,
+          non_empty(bp.logMessage) and "Log message: " .. bp.logMessage or nil,
+          non_empty(bp.condition) and "Condition: " .. bp.condition or nil,
+          non_empty(bp.hitCondition) and "Hit condition: " .. bp.hitCondition or nil,
         }
         local text = table.concat(vim.tbl_filter(not_nil, text_parts), ', ')
         table.insert(qf_list, {

--- a/lua/dap/utils.lua
+++ b/lua/dap/utils.lua
@@ -30,11 +30,13 @@ function M.to_dict(values, get_key, get_value)
 end
 
 
+---@param object? table|string
+---@return boolean
 function M.non_empty(object)
   if type(object) == "table" then
     return next(object) ~= nil
   end
-  return object and #object > 0
+  return object and #object > 0 or false
 end
 
 

--- a/tests/breakpoints_spec.lua
+++ b/tests/breakpoints_spec.lua
@@ -71,5 +71,25 @@ describe('breakpoints', function()
       },
       breakpoints.to_qf_list(breakpoints.get())
     )
+
+    local bps = {
+      [buf] = {
+        {
+          line = 1,
+          condition = ""
+        },
+      }
+    }
+    assert.are.same(
+      {
+        {
+          bufnr = buf,
+          col = 0,
+          lnum = 1,
+          text = "Hello breakpoint"
+        }
+      },
+      breakpoints.to_qf_list(bps)
+    )
   end)
 end)


### PR DESCRIPTION
```
E5108: Error executing lua:
 ~/.local/share/nvim/lazy/nvim-dap/lua/dap/breakpoints.lua:187: invalid
 value (boolean) at index 2 in table for 'concat'
stack traceback:
   [C]: in function 'concat'
   ~/.local/share/nvim/lazy/nvim-dap/lua/dap/breakpoints.lua:187: in function 'to_qf_list'
   ~/.local/share/nvim/lazy/nvim-dap/lua/dap.lua:723: in function 'list_breakpoints'
   ...azy/telescope-dap.nvim/lua/telescope/_extensions/dap.lua:115: in function 'list_breakpoints'
   ~/.config/nvim/lua/plugins/dap/init.lua:76: in function <~/.config/nvim/lua/plugins/dap/init.lua:75>
```