### PR TITLE
Clear children from parent if child session closes

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -1018,9 +1018,16 @@ local function start_debugging(self, request)
       return
     end
 
+    ---@param session Session
     local function on_child_session(session)
       session.parent = self
       self.children[session.id] = session
+      session.on_close['dap.session.child'] = function(s)
+        if s.parent then
+          s.parent.children[s.id] = nil
+          s.parent = nil
+        end
+      end
       session:initialize(config)
       self:response(request, {success = true})
     end

--- a/tests/sessions_spec.lua
+++ b/tests/sessions_spec.lua
@@ -16,7 +16,7 @@ local function run_and_wait_until_initialized(conf, server)
     -- wait for initialize and launch requests
     return (session and session.initialized and #server.spy.requests == 2)
   end)
-  return dap.session()
+  return assert(dap.session(), "Must have session after dap.run")
 end
 
 
@@ -83,5 +83,9 @@ describe('sessions', function()
     )
     local _, child = next(dap.session().children)
     assert.are.same("Subprocess", child.config.name)
+
+    srv2.stop()
+    wait(function() return vim.tbl_count(dap.session().children) == 0 end)
+    assert.are.same({}, dap.session().children)
   end)
 end)


### PR DESCRIPTION
Otherwise the session remains in memory longer than necessary and the
sessions widget continues showing the child session until the parent
session ends.
