### PR TITLE
Use first frame with source as top-frame

### DIFF
--- a/lua/dap/protocol.lua
+++ b/lua/dap/protocol.lua
@@ -1,3 +1,6 @@
+---@meta
+
+
 ---@class dap.ProtocolMessage
 ---@field seq number
 ---@field type "request"|"response"|"event"|string

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -615,9 +615,10 @@ end
 
 
 ---@param frames dap.StackFrame[]
+---@return dap.StackFrame|nil
 local function get_top_frame(frames)
   for _, frame in pairs(frames) do
-    if frame.source and frame.source.path then
+    if frame.source then
       return frame
     end
   end


### PR DESCRIPTION
It doesn't need to have a path. Frames with source reference can be
fetched
