### PR TITLE
Fix lines in scope widget go under a wrong group 

### DIFF
--- a/lua/dap/ui.lua
+++ b/lua/dap/ui.lua
@@ -466,16 +466,18 @@ function M.layer(buf)
       local modifiable = api.nvim_buf_get_option(buf, 'modifiable')
       api.nvim_buf_set_option(buf, 'modifiable', true)
       if not start and not end_ then
-        start = api.nvim_buf_line_count(buf) - 1
+        start = api.nvim_buf_line_count(buf)
         -- Avoid inserting a new line at the end of the buffer
         -- The case of no lines and one empty line are ambiguous;
         -- set_lines(buf, 0, 0) would "preserve" the "empty buffer line" while set_lines(buf, 0, -1) replaces it
         -- Need to use regular end_ = start in other cases to support injecting lines in all other cases
-        if start == 0 and (api.nvim_buf_get_lines(buf, 0, -1, true))[1] == "" then
+        if start == 1 and (api.nvim_buf_get_lines(buf, 0, -1, true))[1] == "" then
+          start = 0
           end_ = -1
         else
           end_ = start
         end
+        print('render, start and end_ computed', start, end_) --, vim.inspect(xs))
       else
         start = start or (api.nvim_buf_line_count(buf) - 1)
         end_ = end_ or start
@@ -507,6 +509,7 @@ function M.layer(buf)
         end
         text = text:gsub('\n', '\\n')
         api.nvim_buf_set_lines(buf, i, i + 1, true, {text})
+        print('set-line', i, text)
         if hl_regions then
           for _, hl_region in pairs(hl_regions) do
             api.nvim_buf_add_highlight(

--- a/lua/dap/ui.lua
+++ b/lua/dap/ui.lua
@@ -477,7 +477,6 @@ function M.layer(buf)
         else
           end_ = start
         end
-        print('render, start and end_ computed', start, end_) --, vim.inspect(xs))
       else
         start = start or (api.nvim_buf_line_count(buf) - 1)
         end_ = end_ or start
@@ -509,7 +508,6 @@ function M.layer(buf)
         end
         text = text:gsub('\n', '\\n')
         api.nvim_buf_set_lines(buf, i, i + 1, true, {text})
-        print('set-line', i, text)
         if hl_regions then
           for _, hl_region in pairs(hl_regions) do
             api.nvim_buf_add_highlight(

--- a/tests/ui_spec.lua
+++ b/tests/ui_spec.lua
@@ -62,6 +62,21 @@ describe('ui', function()
       assert.are.same('bbbb', layer.get(2).item.label)
       assert.are.same('', layer.get(3).item.label)
     end)
+
+    it('can append at the end', function()
+      layer.render({{ label = "e" }}, render_item, nil, nil, nil)
+      local lines = api.nvim_buf_get_lines(buf, 0, -1, true)
+      assert.are.same({
+        'aa',
+        'bbb',
+        'bbbb',
+        '',
+        'dd',
+        'e',
+      }, lines)
+      assert.are.same('dd', layer.get(4).item.label)
+      assert.are.same('e', layer.get(5).item.label)
+    end)
   end)
 
   local opts = {


### PR DESCRIPTION
Fix #888.  When `dap.ui.Layer.render` is called with `start == nil` and `end_ == nil`,  assign `start = 0` only when the buffer contains a single, empty line.  For all other cases, assign `start == line-count` instead of `start == line-count - 1`, which appears to be causing the line swapping issue.
Add a simple test case where the buffer already contains non-empty lines, and a new line is added with `start == nil` and `end_ == nil`, which should now be appended to the end. 
