### PR TITLE
Fix repl single step command cause exit and no jump_frame

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -641,7 +641,9 @@ function Session:event_stopped(stopped)
   end
 
   local should_jump = stopped.reason ~= 'pause' or stopped.allThreadsStopped
-  if self.stopped_thread_id and should_jump then
+  -- Don't continue and allow jump when StoppedEvent.threadId
+  -- is the same as self.stopped_thread_id
+  if self.stopped_thread_id and self.stopped_thread_id ~= stopped.threadId and should_jump then
     if defaults(self).auto_continue_if_many_stopped then
       local thread = self.threads[self.stopped_thread_id]
       local thread_name = thread and thread.name or self.stopped_thread_id


### PR DESCRIPTION
As #898 says, when I am debuggin a single thread cpp program, call `-exec n` with `cpptools` or `n` with `codelldb` makes program suddenly exit.
I found `auto_continue_if_many_stopped` is set for multi-thread debugging, you don't want to jump to the `stopped.threadId` if we now hold a stopped_thread, but the jumping is reasonable if this `StoppedEvent` occurs at the thread we are now hold.