### PR TITLE
fix restart opts not handling nil value

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -696,7 +696,7 @@ end
 
 
 function M.restart(config, opts)
-  local lsession = opts.session or session
+  local lsession = opts and opts.session or session
   if not lsession then
     notify('No active session', vim.log.levels.INFO)
     return
@@ -712,7 +712,7 @@ function M.restart(config, opts)
     end)
   else
     terminate(lsession, nil, nil, vim.schedule_wrap(function()
-      local nopts = vim.deepcopy(opts)
+      local nopts = vim.deepcopy(opts) or {}
       nopts.new = true
       M.run(config, nopts)
     end))


### PR DESCRIPTION
I started to make some custom mappings and created the next mapping:

```lua
vim.keymap.set('n', '<F4>', function() require('dap').restart() end)
```

Then I manually tested it and got and error:
```
E5108: Error executing lua: ...l/share/nvim/site/pack/packer/start/nvim-dap/lua/dap.lua:699: attempt to index local 'opts' (a nil value)
stack traceback:
        ...l/share/nvim/site/pack/packer/start/nvim-dap/lua/dap.lua:699: in function 'restart'
        /Users/artyom/.config/nvim/lua/core/mappings.lua:57: in function </Users/artyom/.config/nvim/lua/core/mappings.lua:57>
```

All other mappings have optional `opts` and I don't have problems with them.

This PR enables optional `opts` like `config` for `restart` function.