### PR TITLE
Pass parent session to adapter factory

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -143,9 +143,13 @@ Both types support the following additional options:
                                        -- retrieved via a source request.
 
 
-`dap.adapters.<name>` can also be set to a function which takes two arguments.
-This first argument is a callback which must be called with the adapter table.
-The second argument is the |dap-configuration| which the user wants to use.
+`dap.adapters.<name>` can also be set to a function which takes three arguments:
+
+- A `on_config` callback. This must be called with the actual adapter table.
+- The |dap-configuration| which the user wants to use.
+- An optional parent session. This is only available if the debug-adapter
+  wants to start a child-session via a `startDebugging` request.
+
 
 This can be used to defer the resolving of the values to when a configuration
 is used. A use-case for this is starting an adapter asynchronous. For example,

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -197,6 +197,8 @@ local DAP_QUICKFIX_CONTEXT = DAP_QUICKFIX_TITLE
 ---@field detached nil|boolean
 
 
+---@alias Dap.AdapterFactory fun(callback: fun(adapter: Adapter), config: Configuration, parent?: Session)
+
 --- Adapter definitions. See `:help dap-adapter` for more help
 ---
 --- An example:
@@ -210,7 +212,7 @@ local DAP_QUICKFIX_CONTEXT = DAP_QUICKFIX_TITLE
 ---   },
 --- }
 --- ```
----@type table<string, Adapter|fun(callback: fun(adapter: Adapter), config: Configuration)>
+---@type table<string, Adapter|Dap.AdapterFactory>
 M.adapters = {}
 
 

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -871,9 +871,6 @@ do
             breakpoints.set_state(bufnr, bp.line, bp)
             if not bp.verified then
               log.info('Server rejected breakpoint', bp)
-              if bp.message then
-                utils.notify(bp.message, vim.log.levels.ERROR)
-              end
             end
           end
         end
@@ -1014,7 +1011,7 @@ local function start_debugging(self, request)
     config.request = body.request
 
     if type(adapter) == "function" then
-      adapter(co_resume_schedule(co), config)
+      adapter(co_resume_schedule(co), config, self)
       adapter = coroutine.yield()
     end
 
@@ -1200,6 +1197,7 @@ function Session.connect(_, adapter, opts, on_connect)
 
   if adapter.executable then
     adapter = spawn_server_executable(adapter)
+    session.adapter = adapter
   end
   log.debug('Connecting to debug adapter', adapter)
   local max_retries = (adapter.options or {}).max_retries or 14


### PR DESCRIPTION
For the `startDebugging` implementation of `vscode-js-debug` the client
needs to connect to the parent adapter instance.

This change enables an adapter configuration like this:

```lua
require("dap").adapters["pwa-node"] = function(on_config, config, parent)
  local target = config["__pendingTargetId"]
  if target and parent then
    local adapter = parent.adapter --[[@as ServerAdapter]]
    on_config({
      type = "server",
      host = "localhost",
      port = adapter.port
    })
  else
    on_config({
      type = "server",
      host = "localhost",
      port = "${port}",
      executable = {
        command = "node",
        args = {"/path/to/js-debug/src/dapDebugServer.js", "${port}"},
      }
    })
  end
end
```
