### PR TITLE
Change startDebugging to connect to parent adapter if type=server with executable

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -1015,6 +1015,14 @@ local function start_debugging(self, request)
       adapter = coroutine.yield()
     end
 
+    -- Prefer connecting to root server again if it is of type server and
+    -- the new adapter would have an executable.
+    -- Spawning a new executable is likely the wrong thing to do
+    if self.adapter.type == "server" and adapter.executable then
+      adapter = vim.deepcopy(self.adapter)
+      adapter.executable = nil
+    end
+
     local expected_types = {"executable", "server"}
     if type(adapter) ~= "table" or not vim.tbl_contains(expected_types, adapter.type) then
       local msg = "Invalid adapter definition. Expected a table with type `executable` or `server`: "

--- a/tests/sessions_spec.lua
+++ b/tests/sessions_spec.lua
@@ -71,7 +71,7 @@ describe('sessions', function()
     }
     run_and_wait_until_initialized(conf1, srv1)
     srv1.client:send_request("startDebugging", {
-      request = "laucnh",
+      request = "launch",
       configuration = {
         type = "dummy2",
         name = "Subprocess"
@@ -87,5 +87,35 @@ describe('sessions', function()
     srv2.stop()
     wait(function() return vim.tbl_count(dap.session().children) == 0 end)
     assert.are.same({}, dap.session().children)
+  end)
+
+  it("startDebugging connects to root adapter if type server with executable", function()
+    local conf1 = {
+      type = 'dummy1',
+      request = 'launch',
+      name = 'Launch file 1',
+    }
+    local session = run_and_wait_until_initialized(conf1, srv1)
+    assert.are.same(1, srv1.client.num_connected)
+    dap.adapters.dummy2 = {
+      type = "server",
+      executable = {
+        command = "echo",
+        args = {"not", "used"},
+      }
+    }
+    srv1.client:send_request("startDebugging", {
+      request = "launch",
+      configuration = {
+        type = "dummy2",
+        name = "Subprocess"
+      }
+    })
+    wait(
+      function() return vim.tbl_count(session.children) == 1 end,
+      function() return dap.session() end
+    )
+    assert.are.same(2, srv1.client.num_connected)
+    dap.terminate()
   end)
 end)


### PR DESCRIPTION
With this change `startDebugging` should work out of the box for debug
adapters configured with type=server and an executable.

For example, for vscode-js-debug, instead of a custom adapter factory
like:

```lua
require("dap").adapters["pwa-node"] = function(on_config, config, parent)
  local target = config["__pendingTargetId"]
  if target and parent then
    local adapter = parent.adapter --[[@as ServerAdapter]]
    on_config({
      type = "server",
      host = "localhost",
      port = adapter.port
    })
  else
    on_config({
      type = "server",
      host = "localhost",
      port = "${port}",
      executable = {
        command = "node",
        args = {"/path/to/js-debug/src/dapDebugServer.js", "${port}"},
      }
    })
  end
end
```

It will be possible to use the simpler definition:

```lua
require("dap").adapters["pwa-node"] = {
  type = "server",
  host = "localhost",
  port = "${port}",
  executable = {
    command = "node",
    args = {"/path/to/js-debug/src/dapDebugServer.js", "${port}"},
  }
}
```
