### PR TITLE
launch.json load: fix type_to_filetypes bug - save user defined for later use

### DIFF
--- a/lua/dap/ext/vscode.lua
+++ b/lua/dap/ext/vscode.lua
@@ -144,6 +144,7 @@ end
 --- Extends dap.configurations with entries read from .vscode/launch.json
 function M.load_launchjs(path, type_to_filetypes)
   type_to_filetypes = vim.tbl_extend('keep', type_to_filetypes or {}, M.type_to_filetypes)
+  M.type_to_filetypes = type_to_filetypes
   local resolved_path = path or (vim.fn.getcwd() .. '/.vscode/launch.json')
   if not vim.loop.fs_stat(resolved_path) then
     return


### PR DESCRIPTION
Hi,

The support for launch.json files is poggers, but there is a small frustrating thing that happens in this scenario:

Let's say I add this to my configuration:
```lua
require('dap.ext.vscode').load_launchjs('.vscode/launch.json', { lldb = { 'c', 'cpp', 'rust' } })
```

Everything is fine, because thanks to the `type_to_filetype` table, everything is mapped correctly.

However when I edit my launch.json file and run `:DapLoadLaunchJSON` (or not because there is an `autocmd` that does that automatically), something like this happens:

The `load_launchjs` is called without arguments so the `types_to_filetypes` table is empty.

The function will import a configuration for `lldb` instead of `c`.

However the `select_config_and_run` function lets you pick from `M.configuration[filetype]`, `filetype` being `vim.api.nvim_buf_get_option(0, 'filetype')`, so `c` in our case.

Here's my quick and dirty fix, it just updates the global `M.types_to_filetypes` every time you call `.load_launchjs` with a matching table.

There is probably a better fix for this, maybe adding a function to setup the `type_to_filetypes` global, but I believe that "saving" the filetypes should be the default, as not doing so would be for specific use cases, such as loading multiple launch.json files, which I think is not what most people do.