### PR TITLE
Make terminate behavior on vim exit configurable per adapter

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -204,6 +204,12 @@ This is controlled via a `Configuration`, which has 3 required fields:
     name: string        -- A user-readable name for the configuration.
 <
 
+There is one optional field to control whether the debuggee is terminated when
+vim exits:
+
+>
+    dont_terminate_on_exit: bool        -- defaults to false
+<
 In addition, a `Configuration` accepts an arbitrary number of further options
 which are debug-adapter-specific.
 

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -220,6 +220,7 @@ M.adapters = {}
 ---@field type string
 ---@field request "launch"|"attach"
 ---@field name string
+---@field dont_terminate_on_exit boolean
 
 --- Configurations per adapter. See `:help dap-configuration` for more help.
 ---
@@ -1017,11 +1018,13 @@ end
 
 function M._vim_exit_handler()
   for _, s in pairs(sessions) do
-    terminate(s)
-    vim.wait(500, function()
-      ---@diagnostic disable-next-line: redundant-return-value
-      return session == nil and next(sessions) == nil
-    end)
+    if not s.config.dont_terminate_on_exit then
+        terminate(s)
+        vim.wait(500, function()
+          ---@diagnostic disable-next-line: redundant-return-value
+          return session == nil and next(sessions) == nil
+        end)
+    end
   end
   M.repl.close()
 end


### PR DESCRIPTION
When developing I treat vim instances as disposable, opening and closing them as I go. When I have the debuggee running as a separate process I don't always want it to terminate if vim exits with an open session. 

I have 0 experience with lua or vim plugin development but I tried to make this configurable with a new option on the adapter. I'm not sure how to test the exit handler.

I'm not very happy with the negative phrasing of the option. I initially had it as `terminate_on_exit`, but wasn't sure how to actually default this configuration, and this meant `nil` and `true` were the same when it's eventually checked and I did not like that. So I made the option negative.

this is an example config I use 

```
table.insert(py_configs, {
    type = 'python';
    request = 'attach';
    name = 'Attach Running APP';
    dont_terminate_on_exit = true,
    connect = {
        host = '127.0.0.1',
        port = '${env:DEBUGPY_PORT}',
    },
})
```
