### PR TITLE
remove REPL history clear when starting a new session

### DIFF
--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -7,7 +7,7 @@ local history = {
   last = nil,
   entries = {},
   idx = 1,
-  max_size = 5000,
+  max_size = 100,
 }
 
 local autoscroll = vim.fn.has('nvim-0.7') == 1

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -6,7 +6,8 @@ local M = {}
 local history = {
   last = nil,
   entries = {},
-  idx = 1
+  idx = 1,
+  max_size = 5000,
 }
 
 local autoscroll = vim.fn.has('nvim-0.7') == 1
@@ -226,6 +227,9 @@ function execute(text)
     end
   else
     history.last = text
+    if #history.entries == history.max_size then
+      table.remove(history.entries, 1)
+    end
     table.insert(history.entries, text)
     history.idx = #history.entries + 1
   end
@@ -245,8 +249,7 @@ function execute(text)
     return
   elseif vim.tbl_contains(M.commands.clear, text) then
     if repl.buf and api.nvim_buf_is_loaded(repl.buf) then
-      local layer = ui.layer(repl.buf)
-      layer.render({}, tostring, {}, 0, - 1)
+      M.clear_output()
     end
     return
   end
@@ -383,10 +386,7 @@ function M.append(line, lnum, opts)
 end
 
 
-function M.clear()
-  history.last = nil
-  history.entries = {}
-  history.idx = 1
+function M.clear_output()
   if repl.buf and api.nvim_buf_is_loaded(repl.buf) then
     local layer = ui.layer(repl.buf)
     layer.render({}, tostring, {}, 0, - 1)

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -249,7 +249,7 @@ function execute(text)
     return
   elseif vim.tbl_contains(M.commands.clear, text) then
     if repl.buf and api.nvim_buf_is_loaded(repl.buf) then
-      M.clear_output()
+      M.clear()
     end
     return
   end
@@ -386,7 +386,7 @@ function M.append(line, lnum, opts)
 end
 
 
-function M.clear_output()
+function M.clear()
   if repl.buf and api.nvim_buf_is_loaded(repl.buf) then
     local layer = ui.layer(repl.buf)
     layer.render({}, tostring, {}, 0, - 1)

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -1623,7 +1623,7 @@ end
 --- Initialize the debug session
 ---@param config Configuration
 function Session:initialize(config)
-  vim.schedule(repl.clear_output)
+  vim.schedule(repl.clear)
   local adapter_responded = false
   self.config = config
   self:request('initialize', {

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -1623,6 +1623,7 @@ end
 --- Initialize the debug session
 ---@param config Configuration
 function Session:initialize(config)
+  vim.schedule(repl.clear_output)
   local adapter_responded = false
   self.config = config
   self:request('initialize', {

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -1623,7 +1623,6 @@ end
 --- Initialize the debug session
 ---@param config Configuration
 function Session:initialize(config)
-  vim.schedule(repl.clear)
   local adapter_responded = false
   self.config = config
   self:request('initialize', {


### PR DESCRIPTION
Currently starting a new session clears the REPL history. I see no reason why this is required, and actually I have found quite common the need to reuse REPL command between sessions.
Other IDEs (e.g. vscode) also keep history between sessions.