### PR TITLE
repl: Move cursor to the end of line on select_history (up/down)

### DIFF
--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -336,6 +336,7 @@ local function select_history(delta)
   if text then
     local lnum = vim.fn.line('$') - 1
     api.nvim_buf_set_lines(repl.buf, lnum, lnum + 1, true, {'dap> ' .. text })
+    vim.fn.setcursorcharpos({ vim.fn.line('$'), vim.fn.col('$') })  -- move cursor to the end of line
   end
 end
 


### PR DESCRIPTION
In most of the REPLs (ipython, bash/zsh shell, etc.) a typical behavior on navigating history is to move the cursor to the end of line when pressed <up> or <down>. Currently DAP repl puts the cursor at the beginning of the line, which feels awkward. This PR fixes the behavior to be more consistent with conventional behaviors.
