### PR TITLE
fix: Exit code 1 warning at the end of a debug session on Windows

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -1201,9 +1201,14 @@ local function spawn_server_executable(executable, session)
   stderr:read_start(read_output('stderr', stderr))
   stdout:read_start(read_output('stdout', stdout))
 
+  local is_windows = vim.fn.has("win32")
   session.on_close["dap.server_executable"] = function()
     if not handle:is_closing() then
-      handle:kill("sigterm")
+      if is_windows == 1 then
+        handle:kill("sighup")
+      else
+        handle:kill("sigterm")
+      end
     end
   end
 end

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -1206,7 +1206,7 @@ function Session.connect(_, adapter, opts, on_connect)
       close = function(cb)
         _close(function()
           if not handle:is_closing() then
-            handle:kill("sigterm")
+            handle:kill("SIGTERM")
           end
           if cb then
             cb()

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -1202,11 +1202,16 @@ function Session.connect(_, adapter, opts, on_connect)
     session.adapter = adapter
 
     if handle then
+      local is_windows = vim.fn.has("win32")
       local _close = close
       close = function(cb)
         _close(function()
           if not handle:is_closing() then
-            handle:kill("SIGTERM")
+            if is_windows == 1 then
+                handle:kill("sighup")
+            else
+                handle:kill("sigterm")
+            end
           end
           if cb then
             cb()


### PR DESCRIPTION
On Windows, when using a server type debug adapter that is executed (in this case codelldb) I received the following warning after a debug session ended:

> ...codelldb.CMD exited with code 1

Changing "sigterm" to "SIGTERM" in the client close function fixes this.