### PR TITLE
Focus window with breakpoint on stopped event

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -375,6 +375,7 @@ end
 local function set_cursor(win, line, column)
   local ok, err = pcall(api.nvim_win_set_cursor, win, { line, column - 1 })
   if ok then
+    api.nvim_set_current_win(win)
     api.nvim_win_call(win, function()
       api.nvim_command('normal! zv')
     end)


### PR DESCRIPTION
So far it set the cursor, but didn't change the active window.

See https://github.com/mfussenegger/nvim-dap/issues/980#issuecomment-1625103893
