### PR TITLE
Use `ps ah -u $USER` for `dap.utils.pick_process`

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -1161,7 +1161,7 @@ Lua module: dap.utils
 
 pick_process({opts})                                    *dap.utils.pick_process*
     Show a prompt to select a process pid
-    Requires `ps ah` on Linux/Mac and `tasklist /nh /fo csv` on windows.
+    Requires `ps ah -u $USER` on Linux/Mac and `tasklist /nh /fo csv` on windows.
 
 
     Parameters:

--- a/lua/dap/utils.lua
+++ b/lua/dap/utils.lua
@@ -55,7 +55,7 @@ end
 function M.get_processes()
   local is_windows = vim.fn.has('win32') == 1
   local separator = is_windows and ',' or ' \\+'
-  local command = is_windows and {'tasklist', '/nh', '/fo', 'csv'} or {'ps', 'ah'}
+  local command = is_windows and {'tasklist', '/nh', '/fo', 'csv'} or {'ps', 'ah', '-u', os.getenv("USER")}
   -- output format for `tasklist /nh /fo` csv
   --    '"smss.exe","600","Services","0","1,036 K"'
   -- output format for `ps ah`
@@ -97,7 +97,7 @@ end
 
 
 --- Show a prompt to select a process pid
---- Requires `ps ah` on Linux/Mac and `tasklist /nh /fo csv` on windows.
+--- Requires `ps ah -u $USER` on Linux/Mac and `tasklist /nh /fo csv` on windows.
 --
 --- Takes an optional `opts` table with the following options:
 ---


### PR DESCRIPTION
To show more processes. Otherwise it's restricted to terminal processes.
