### PR TITLE
Add support for unix domain sockets and named pipes

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -73,8 +73,13 @@ The `Adapter` needs to contain a `type`, which can be one of:
   this case nvim-dap will spawn the given process and communicate with it using
   stdio.
 
-- `server`, to indicate that nvim-dap can connect to an already-running
-  debug adapter via TCP.
+- `server`, to connect to a debug adapter via TCP.
+  The adapter must be running, or started with a debug session via a
+  `executable` configuration of the adapter. See the options further below.
+
+- `pipe`, to connect to a adebug adapter via a unix domain socket or named pipe.
+  The adapter must be running, or started with a debug session via a
+  `executable` configuration of the adapter. See the options further below.
 
 For `executable` the following options are supported:
 
@@ -126,7 +131,27 @@ For `server` the following options are supported:
     }
 
 
-Both types support the following additional options:
+For `pipe` the following options are supported:
+
+
+    pipe: string      -- Absolute path to the pipe file.
+                      -- If `${pipe}` nvim-dap generates a temporary filename
+                      -- that is intended for use with `executable`
+
+    -- nvim-dap can optionally launch the debug-adapter on each new debug session
+    -- And then connect to the socket or named pipe
+    executable?: {
+      command: string       -- command that spawns the server
+      args?: string[]       -- command arguments
+                            -- ${pipe} used in the args is replaced with a
+                            -- dynamically resolved temporary file
+      detached?: boolean    -- Spawn the debug adapter in detached mode.
+                            -- Defaults to true.
+      cwd?: string          -- Working directory
+    }
+
+
+All types support the following additional options:
 
 >
     options?: {

--- a/tests/pipe_spec.lua
+++ b/tests/pipe_spec.lua
@@ -1,0 +1,53 @@
+local dap = require('dap')
+
+local function wait(predicate, msg)
+  vim.wait(1000, predicate)
+  local result = predicate()
+  assert.are_not.same(false, result, msg and vim.inspect(msg()) or nil)
+  assert.are_not.same(nil, result)
+end
+
+
+describe('dap with fake pipe server', function()
+  local server
+  before_each(function()
+    server = require('tests.server').spawn({ new_sock = vim.loop.new_pipe })
+    dap.adapters.dummy = server.adapter
+  end)
+  after_each(function()
+    server.stop()
+    dap.close()
+    require('dap.breakpoints').clear()
+    wait(function() return dap.session() == nil end)
+  end)
+  it("can connect and terminate", function()
+    local config = {
+      type = 'dummy',
+      request = 'launch',
+      name = 'Launch file',
+    }
+    dap.run(config)
+    wait(function()
+      local session = dap.session()
+      return session and session.initialized and #server.spy.requests == 2
+    end)
+    local session = dap.session()
+    assert.is_not_nil(session)
+    assert.are.same(1, server.client.num_connected)
+    dap.terminate()
+    wait(function()
+      return (
+        dap.session() == nil
+        and #server.spy.events == 2
+        and server.spy.events[2].event == "terminated"
+        and server.client.num_connected == 0
+      )
+    end, function() return server.spy.events end)
+    assert.is_nil(dap.session())
+    assert(session)
+    assert.is_true(session.closed)
+    ---@diagnostic disable-next-line: invisible
+    assert.is_true(session.handle:is_closing())
+    assert.are.same(0, server.client.num_connected)
+  end)
+end)


### PR DESCRIPTION
For adapters like cmake which don't support stdin or TCP

Closes https://github.com/mfussenegger/nvim-dap/issues/924

For example:

    local dap = require("dap")
    dap.adapters.cmake = {
      type = "pipe",
      pipe = "${pipe}",
      executable = {
        command = "cmake",
        args = {"--debugger", "--debugger-pipe", "${pipe}"}
      }
    }
    dap.configurations.cmake = {
      {
        name = "Build",
        type = "cmake",
        request = "launch",
      }
    }
