### PR TITLE
support register variable/command, add unit test

### DIFF
--- a/tests/variable_spec.lua
+++ b/tests/variable_spec.lua
@@ -1,0 +1,76 @@
+
+describe('variable.builtin', function()
+  it('expand file', function()
+    local result = require("dap").expand_config_variables("${file}")
+    assert.are.same(vim.fn.expand("%:p"), result)
+  end)
+
+  it('expand file multiply', function()
+    local result = require("dap").expand_config_variables("${file}-${fileBasename}-${file}")
+    assert.are.same(vim.fn.expand("%:p") .. '-' .. vim.fn.expand("%:t") .. '-' .. vim.fn.expand("%:p"), result)
+  end)
+
+  it('expand workspaceFolder', function()
+    local result = require("dap").expand_config_variables("--${workspaceFolder}--")
+    assert.are.same('--' .. vim.fn.getcwd() .. '--', result)
+  end)
+end)
+
+describe('variable.env', function()
+  it('expand env:HOME', function()
+    local home = require("dap").expand_config_variables("${env:HOME}")
+    assert.are.same(os.getenv("HOME"), home)
+
+    local not_home = require("dap").expand_config_variables("env:HOME")
+    assert.are.same("env:HOME", not_home)
+  end)
+
+  it('expand env complex', function()
+    do
+      local result = require("dap").expand_config_variables("${env:HOME}--${env:PATH}")
+      assert.are.same(os.getenv("HOME") .. "--" .. os.getenv("PATH"), result)
+    end
+    do
+      local result = require("dap").expand_config_variables("${env:HOME}--${env:PATH}--${env:HOME}")
+      assert.are.same(os.getenv("HOME") .. "--" .. os.getenv("PATH") .. "--" .. os.getenv("HOME"), result)
+    end
+  end)
+end)
+
+describe('variable.command', function()
+  it('expand pickProcess', function()
+    local options
+    -- mock vim.ui.select
+    vim.ui.select = function(options_, _, on_choice)
+      options = options_
+      on_choice(options_[1])
+    end
+    local result = require("dap").expand_config_variables("${command:pickProcess}")
+    -- pid is number
+    assert.are.same(tostring(options[1].pid), result)
+  end)
+end)
+
+describe('variable.register', function()
+  it('static handle', function()
+    require("dap").register_command("test", function()
+      return "value"
+    end)
+
+    local result = require("dap").expand_config_variables("${command:test}")
+    assert.are.same("value", result)
+  end)
+
+  it('asynchronous handle', function()
+    require("dap").register_command("coroutine", function()
+      local co = coroutine.running()
+      return coroutine.create(function()
+        vim.defer_fn(function()
+          coroutine.resume(co, "defer_value")
+        end, 2000)
+      end)
+    end)
+    local result = require("dap").expand_config_variables("${command:coroutine}")
+    assert.are.same("defer_value", result)
+  end)
+end)


### PR DESCRIPTION
# Register command mechanism
Regarding to [Command](https://code.visualstudio.com/api/extension-guides/command#creating-new-commands), vscode has a mechanism named `Command`, which can be used as [Command Variable](https://code.visualstudio.com/docs/editor/variables-reference#_command-variables)
> If the predefined variables from above are not sufficient, you can use any VS Code command as a variable through the ${command:commandID} syntax.
> A command variable is replaced with the (string) result from the command evaluation. The implementation of a command can range from a simple calculation with no UI, to some sophisticated functionality based on the UI features available via VS Code's extension API. If the command returns anything other than a string, then the variable replacement will not complete. Command variables must return a string.

For example, [vscode-cmake-tools](https://github.com/microsoft/vscode-cmake-tools/blob/main/docs/debug-launch.md#gdb) extension support lots of  `command variable`, which can be used in launch.json

```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "(gdb) Launch",
            "type": "cppdbg",
            "request": "launch",
            // Resolved by CMake Tools:
            "program": "${command:cmake.launchTargetPath}",
            "cwd": "${workspaceFolder}",
            "environment": [
                {
                    // add the directory where our target was built to the PATHs
                    // it gets resolved by CMake Tools:
                    "name": "PATH",
                    "value": "${env:PATH}:${command:cmake.getLaunchTargetDirectory}"
                }
            ]
        }
    ]
}
```

# What did I do

I add API named `dap.register_command(identifier, handler)` to do something same to [vscode.commands.registerCommand](https://code.visualstudio.com/api/references/vscode-api#commands.registerCommand) .  Which can help extension developer to enhance ability of dap.

 e.g.
  ```lua
require("dap").register_command("cmake.launchTargetPath", function()
     // run cmake build task, then return executable path
     // can be a asynchronous coroutine
     return coroutine.create(function()
           // fake cmake build step
           vim.defer_fn(function()
              coroutine.resume(co, "/path/to/exectutable")
            end, 2000)
    end)
end)
```

# Some Unit Test Added

* normal variable
* env varialbe
* register command
* register asnyc command
