### PR TITLE
Add a new option dap.repl.show_tree: whether to show the tree in REPL

### DIFF
--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -11,6 +11,7 @@ local history = {
 }
 
 local autoscroll = vim.fn.has('nvim-0.7') == 1
+M.show_tree = true
 
 local function get_session()
   return require('dap').session()
@@ -157,7 +158,7 @@ local function evaluate_handler(err, resp)
   end
   local layer = ui.layer(repl.buf)
   local attributes = (resp.presentationHint or {}).attributes or {}
-  if resp.variablesReference > 0 or vim.tbl_contains(attributes, 'rawString') then
+  if M.show_tree and (resp.variablesReference > 0 or vim.tbl_contains(attributes, 'rawString')) then
     local spec = require('dap.entity').variable.tree_spec
     local tree = ui.new_tree(spec)
     -- tree.render would "append" twice, once for the top element and once for the children


### PR DESCRIPTION
A new option `show_tree` can be set by users to configure whether to
show the expandable tree in the DAP REPL window. Concise and simple
representation in the REPL would be useful for many languages,
see #737 for an example (python).

The option can be configured using, for instance:

```
require('dap.repl').show_tree = false
```

TODO: Add documentation in `doc/dap.txt`