### PR TITLE
Increase priority of signs

### DIFF
--- a/lua/dap/breakpoints.lua
+++ b/lua/dap/breakpoints.lua
@@ -49,7 +49,7 @@ function M.update(breakpoint)
           ns,
           get_sign_name(bp),
           bp.buf,
-          { lnum = bp.line; priority = 11; }
+          { lnum = bp.line; priority = 21; }
         )
       end
       bp.state.verified = breakpoint.verified
@@ -80,7 +80,7 @@ function M.set_state(bufnr, lnum, state)
         ns,
         'DapBreakpointRejected',
         bufnr,
-        { lnum = lnum; priority = 11; }
+        { lnum = lnum; priority = 21; }
       )
     end
   end
@@ -121,7 +121,7 @@ function M.toggle(opts, bufnr, lnum)
     ns,
     sign_name,
     bufnr,
-    { lnum = lnum; priority = 11; }
+    { lnum = lnum; priority = 21; }
   )
   if sign_id ~= -1 then
     bp_by_sign[sign_id] = bp

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -558,7 +558,7 @@ local function jump_to_frame(session, frame, preserve_focus_hint, stopped)
     return
   end
   vim.fn.bufload(bufnr)
-  local ok, failure = pcall(vim.fn.sign_place, 0, session.sign_group, 'DapStopped', bufnr, { lnum = frame.line; priority = 12 })
+  local ok, failure = pcall(vim.fn.sign_place, 0, session.sign_group, 'DapStopped', bufnr, { lnum = frame.line; priority = 22 })
   if not ok then
     utils.notify(failure, vim.log.levels.ERROR)
   end


### PR DESCRIPTION
When severity_sort is enabled, diagnostic sign priority can be raised above 10 (1 per severity). And so by putting it at 21 and 22, dap breakpoints are always shown, even when there are diagnostics

(Related to #197 )