### PR TITLE
Stop terminating "attached" debugees when exiting Vim

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -1038,12 +1038,12 @@ function M._vim_exit_handler()
       s:disconnect({ terminateDebuggee = false })
     else
       terminate(s)
-      vim.wait(500, function()
-        ---@diagnostic disable-next-line: redundant-return-value
-        return session == nil and next(sessions) == nil
-      end)
     end
   end
+  vim.wait(500, function()
+    ---@diagnostic disable-next-line: redundant-return-value
+    return session == nil and next(sessions) == nil
+  end)
   M.repl.close()
 end
 

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -1034,11 +1034,15 @@ end
 
 function M._vim_exit_handler()
   for _, s in pairs(sessions) do
-    terminate(s)
-    vim.wait(500, function()
-      ---@diagnostic disable-next-line: redundant-return-value
-      return session == nil and next(sessions) == nil
-    end)
+    if s.config.request == "attach" then
+      s:disconnect({ terminateDebuggee = false })
+    else
+      terminate(s)
+      vim.wait(500, function()
+        ---@diagnostic disable-next-line: redundant-return-value
+        return session == nil and next(sessions) == nil
+      end)
+    end
   end
   M.repl.close()
 end


### PR DESCRIPTION
Hi,

I mostly use DAP to debug a long-running server process. My workflow has me closing Vim frequently, and whenever I do without remembering to disconnect the debugger, I accidentally terminate the server. Is that intended behavior? Why would DAP want to manage the lifecycle of an "attached" debugee?

Anyways, this hack seems to fix it for me. This was the smallest change I could think of, but it's a breaking change. Perhaps it would be better placed as a per configuration option (`terminate_on_vim_exit = false` or `on_vim_exit = "terminate" | "disconnect"`), which defaults to termination, but allows opting out?

I'm not particularly attached to any of this. Take it or leave it, or modify it as you see fit :)

Thanks for your work on this plugin 👍 