### PR TITLE
Support source maps between editor and debugger file paths

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -155,17 +155,23 @@ All types support the following additional options:
 
 >
     options?: {
-      initialize_timeout_sec?: number  -- How many seconds the client waits for a
-                                       -- response on a initialize request before
-                                       -- emitting a warning. Defaults to 4
+      initialize_timeout_sec?: number    -- How many seconds the client waits for a
+                                         -- response on a initialize request before
+                                         -- emitting a warning. Defaults to 4
 
-      disconnect_timeout_sec?: number  -- How many seconds the client waits for
-                                       -- a disconnect response from the debug
-                                       -- adapter before emitting a warning and
-                                       -- closing the connection. Defaults to 3
+      disconnect_timeout_sec?: number    -- How many seconds the client waits for
+                                         -- a disconnect response from the debug
+                                         -- adapter before emitting a warning and
+                                         -- closing the connection. Defaults to 3
 
-      source_filetype?: string         -- The filetype to use for content
-                                       -- retrieved via a source request.
+      source_filetype?: string           -- The filetype to use for content
+                                         -- retrieved via a source request.
+
+      source_map?: table<string, string> -- A table mapping path prefixes from
+                                         -- the editor to the debugger. This is
+                                         -- typically only needed when connecting
+                                         -- to a debugger remotely. Environment
+                                         -- variables are expanded.
 
 
 `dap.adapters.<name>` can also be set to a function which takes three arguments:

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -169,6 +169,7 @@ local DAP_QUICKFIX_CONTEXT = DAP_QUICKFIX_TITLE
 ---@field initialize_timeout_sec nil|number
 ---@field disconnect_timeout_sec nil|number
 ---@field source_filetype nil|string
+---@field source_map nil|table<string, string>
 
 ---@class ExecutableAdapter : Adapter
 ---@field type "executable"


### PR DESCRIPTION
When nvim-dap is running on a separate machine from the debugger then Nvim and the debugger will use different paths for source files. For example, if Nvim is running on a machine where the source tree is located at `/a/project/foo` and the debugger is running on a separate machine where the source tree is located at `/b/project/foo`, when nvim-dap tries to set a breakpoint it will use `/a/project/foo/` in the breakpoint location. When the debugger receives this request it will not set the breakpoint correctly because the debugger does not have any files at `/a/project/foo`.

The `source_map` option instructs nvim-dap to convert paths as seen by the editor and nvim-dap itself to the paths as the debugger sees them. The opposite mapping takes place when nvim-dap receives stack frame or source file information from the debugger.

Note that this is different than the "source map" option provided by many debuggers themselves (such as codelldb's "sourceMap" option or GDB's "substitute-path" setting). Those options convert _compiled_ source paths (i.e. the path of the source file when the binary was compiled) into the debugger's path namespace (`/b/project/foo` in our example).
