### PR TITLE
fix: do not append text each time a widgets is opened

### DIFF
--- a/lua/dap/ui.lua
+++ b/lua/dap/ui.lua
@@ -261,6 +261,8 @@ function M.new_tree(opts)
     end,
 
     render = function(layer, value, on_done, lnum, end_)
+      lnum = lnum or 0
+      end_ = end_ or -1
       layer.render({value}, opts.render_parent, nil, lnum, end_)
       if not opts.has_children(value) then
         if on_done then


### PR DESCRIPTION
Fixes #1042.

This is a really naive approach at solving the problem and I'm not sure if this somehow affects other places in the codebase. Since `layer.render` is being called without a parameter for `lnum` and `end_` inside each widget, the render function appends the widget content instead of replacing it (wich does happend when the widget ir refresh. I saw that in that call 0 and -1 were being passed as values for `lnum` and `end_`, so I tried doing the same here and it worked).