### PR TITLE
Ensure threads floating win closes on frame selection

### DIFF
--- a/lua/dap/entity.lua
+++ b/lua/dap/entity.lua
@@ -365,7 +365,7 @@ function threads_spec.compute_actions(info)
       label = 'Jump to frame',
       fn = function(_, frame)
         session:_frame_set(frame)
-        if vim.bo.bufhidden == 'wipe' and context.view then
+        if context.view and vim.bo[context.view.buf].bufhidden == 'wipe' then
           context.view.close()
         end
       end


### PR DESCRIPTION
`_frame_set` changes the buffer and then `vim.bo.bufhidden` returned the
wrong value.
