### PR TITLE
Stop always replacing with last scope

### DIFF
--- a/lua/dap/ui.lua
+++ b/lua/dap/ui.lua
@@ -261,8 +261,6 @@ function M.new_tree(opts)
     end,
 
     render = function(layer, value, on_done, lnum, end_)
-      lnum = lnum or 0
-      end_ = end_ or -1
       layer.render({value}, opts.render_parent, nil, lnum, end_)
       if not opts.has_children(value) then
         if on_done then

--- a/lua/dap/ui/widgets.lua
+++ b/lua/dap/ui/widgets.lua
@@ -154,15 +154,17 @@ M.scopes = {
     local layer = view.layer()
     local scopes = frame.scopes or {}
     local render
-    render = function(idx, scope)
+    render = function(idx, scope, replace)
       if not scope then
         return
       end
+
       tree.render(layer, scope, function()
         render(next(scopes, idx))
-      end)
+      end, replace and 0 or nil, replace and -1 or nil)
     end
-    render(next(scopes))
+    local idx, scope = next(scopes)
+    render(idx, scope, true)
   end,
 }
 


### PR DESCRIPTION
`lnum` and `end_` need to be set to `nil` when appending additional scopes to the widget, otherwise the final scope overwrites all previous ones. In the case of `lldb`, where you have 'Local', 'Global', and 'Registers', only the last scope 'Registers' would be drawn to the widget.