### PR TITLE
Fix repl expressions leave an empty prompt in the middle (#1052)

### DIFF
--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -151,7 +151,7 @@ local function evaluate_handler(err, resp)
   if err then
     local message = utils.fmt_error(err)
     if message then
-      M.append(message)
+      M.append(message, nil, { newline = false })
     end
     return
   end

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -164,18 +164,13 @@ local function evaluate_handler(err, resp)
     -- Appending twice would result in a intermediate "dap> " prompt
     -- To avoid that this eagerly fetches the children; pre-renders the region
     -- and lets tree.render override it
+    local lnum = api.nvim_buf_line_count(repl.buf) - 1
     if spec.has_children(resp) then
       spec.fetch_children(resp, function()
-        local lnum = api.nvim_buf_line_count(repl.buf) - 1
-        local lines = {''}
-        for _ = 1, #resp.variables do
-          table.insert(lines, '')
-        end
-        api.nvim_buf_set_lines(repl.buf, -1, -1, true, lines)
         tree.render(layer, resp, nil, lnum, -1)
       end)
     else
-      tree.render(layer, resp)
+      tree.render(layer, resp, nil, lnum, -1)
     end
   else
     M.append(resp.result, nil, { newline = false })

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -178,8 +178,7 @@ local function evaluate_handler(err, resp)
       tree.render(layer, resp)
     end
   else
-    local lines = vim.split(resp.result, '\n', { trimempty = true })
-    layer.render(lines)
+    M.append(resp.result, nil, { newline = false })
   end
 end
 
@@ -377,10 +376,14 @@ function M.append(line, lnum, opts)
     lnum = api.nvim_buf_line_count(buf) - 1
     if opts.newline == false then
       local last_line = api.nvim_buf_get_lines(buf, -2, -1, true)[1]
-      if vim.startswith(last_line, 'dap> ') then
+      local col_start = #last_line
+      if last_line == 'dap> ' then
+        -- remove the empty prompt
+        col_start = 0
+      elseif vim.startswith(last_line, 'dap> ') then
         table.insert(lines, 1, '')
       end
-      api.nvim_buf_set_text(buf, lnum, #last_line, lnum, #last_line, lines)
+      api.nvim_buf_set_text(buf, lnum, col_start, lnum, #last_line, lines)
     else
       api.nvim_buf_set_lines(buf, -1, -1, true, lines)
     end

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -376,14 +376,17 @@ function M.append(line, lnum, opts)
     lnum = api.nvim_buf_line_count(buf) - 1
     if opts.newline == false then
       local last_line = api.nvim_buf_get_lines(buf, -2, -1, true)[1]
-      local col_start = #last_line
+      local insert_pos = #last_line
       if last_line == 'dap> ' then
-        -- remove the empty prompt
-        col_start = 0
+        -- insert right in front of the empty prompt
+        insert_pos = 0
+        if lines[#lines] ~= '' then
+          table.insert(lines, #lines + 1, '')
+        end
       elseif vim.startswith(last_line, 'dap> ') then
         table.insert(lines, 1, '')
       end
-      api.nvim_buf_set_text(buf, lnum, col_start, lnum, #last_line, lines)
+      api.nvim_buf_set_text(buf, lnum, insert_pos, lnum, insert_pos, lines)
     else
       api.nvim_buf_set_lines(buf, -1, -1, true, lines)
     end


### PR DESCRIPTION
Here is a few things I learned along the way and how I approached fixing #1052.
* REPL buffer is based on `buftype=prompt`, where nvim makes sure that there is always a prompt at the end of buffer in insert mode (`dap> ` ).
* When a new command is entered, `exec` function in `repl.lua` is executed (registered via `vim.fn.prompt_setcallback`). nvim does not put the next prompt until callback returns, so, within the callback, new lines can simply be appendend at the end of the buffer. (e.g. `.help` command does not leave an empty prompt in the middle).
* Things get a bit tricky with expression command because when a DAP server request comes back, nvim-dap is aldready outside of the callback, and there is an empty prompt at the end of the buffer. Two options here so not to leave an empty prompt in the middle, 
  1. insert the new line(s) right in front of the empty prompt
  2. overwrite the last line with the new line(s)
* `append` function inside `repl.lua` is updated to apply the first option. `evaluate_handler` now calls this function instead of `layer.render` where possible.
* The second opton is used where `tree.render` is called inside `evaluate_handler`.
