### PR TITLE
Eagerly load lazy variables when expanding children

### DIFF
--- a/lua/dap/protocol.lua
+++ b/lua/dap/protocol.lua
@@ -74,6 +74,9 @@
 ---@field variables? table<string, dap.Variable> by variable name. Not part of spec
 
 
+---@class dap.VariableResponse
+---@field variables dap.Variable[]
+
 ---@class dap.Variable
 ---@field name string
 ---@field value string


### PR DESCRIPTION
As described in https://github.com/mfussenegger/nvim-dap/issues/1062
Some debug adapters heavily use the lazy hint.

For example, a collapsed list is initially displayed as:

    settings: ArrayList@50 size=1

That's good. But after expanding, the contained items looke like this:

    settings: ArrayList@50 size=1
      0: Assignment@66

Each individual item had to be expanded to show the value:

    settings: ArrayList@50 size=1
      0: Assignment@66 "Assignment{column='stats.jobs_log_size', expressions=[1024]}"

This removes the intermediate step, to go from:

    settings: ArrayList@50 size=1

Straight to:

    settings: ArrayList@50 size=1
      0: Assignment@66 "Assignment{column='stats.jobs_log_size', expressions=[1024]}"
