### PR TITLE
Start seq number at 1

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -1106,7 +1106,7 @@ local function new_session(adapter, opts, handle)
     message_callbacks = {};
     message_requests = {};
     initialized = false;
-    seq = 0;
+    seq = 1;
     stopped_thread_id = nil;
     current_frame = nil;
     threads = {};


### PR DESCRIPTION
From the spec:

> Sequence number of the message (also known as message ID). The `seq` for
> the first message sent by a client or debug adapter is 1, and for each
> subsequent message is 1 greater than the previous message sent by that
> actor.
