### PR TITLE
Show last message in statusline

### DIFF
--- a/lua/dap/progress.lua
+++ b/lua/dap/progress.lua
@@ -48,13 +48,12 @@ function M.status()
   if not session then
     return ''
   end
-  local msg = M.poll_msg() or last_msg
-  if msg then
-    last_msg = msg
-    return msg
-  else
-    return ''
+  local msg = last_msg
+  for more in M.poll_msg do
+    msg = more
   end
+  last_msg = msg
+  return msg or ''
 end
 
 


### PR DESCRIPTION
If there are pending messages, they would previously be displayed one by one in the status line on each redraw (typically when moving the cursor). Instead, the last message is shown always.

This may have been the intended behavior, but the documentation for `dap.status()` does not mention it. If so, please close this PR.