### PR TITLE
Prioritize local debugging method

### DIFF
--- a/lua/dap/ext/vscode.lua
+++ b/lua/dap/ext/vscode.lua
@@ -204,7 +204,7 @@ function M.load_launchjs(path, type_to_filetypes)
           table.remove(dap_configurations, i)
         end
       end
-      table.insert(dap_configurations, config)
+      table.insert(dap_configurations, 1, config)
       dap.configurations[filetype] = dap_configurations
     end
   end


### PR DESCRIPTION
`load_launchjs` is  usually called after setting up `dap.configurations`, this leads to the local settings being put at the bottom of the methods selection list. But most of the time, user would prefer it to be at the top for convenience.