### PR TITLE
Ensure dap.status() shows start progress

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -1089,9 +1089,8 @@ function M.set_session(new_session)
     session = new_session
   else
     local _, lsession = next(sessions)
-    if lsession then
-      lazy.progress.report('Running: ' .. lsession.config.name)
-    end
+    local msg = lsession and ("Running: " .. lsession.config.name) or ""
+    lazy.progress.report(msg)
     session = lsession
   end
 end

--- a/lua/dap/progress.lua
+++ b/lua/dap/progress.lua
@@ -44,10 +44,6 @@ function M.poll_msg()
 end
 
 function M.status()
-  local session = require('dap').session()
-  if not session then
-    return ''
-  end
   local msg = M.poll_msg() or last_msg
   if msg then
     last_msg = msg


### PR DESCRIPTION
nvim-dap reports `Launching debug adapter` before evaluating a adapter
function:

    progress.report('Launching debug adapter')

But that message was never shown in `dap.status()` because at that point
no session is active and `status()` returned a `''`.

If the adapter function takes a long time, it gave
the impression that nothing was happening.

Solution:

Always show the last message in `status()`, and send a `""` if a session
closes.
