### PR TITLE
Allow to configure max wait timeout for pipe adapter

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -150,6 +150,13 @@ For `pipe` the following options are supported:
       cwd?: string          -- Working directory
     }
 
+    options?: {
+      timeout?: integer  -- Max amount of time in ms to wait between spawning
+                         -- the executable and connecting to the pipe. This
+                         -- gives the executable time to create the pipe.
+                         -- Defaults to 5000ms
+    }
+
 
 All types support the following additional options:
 

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -193,10 +193,15 @@ local DAP_QUICKFIX_CONTEXT = DAP_QUICKFIX_TITLE
 ---@field executable nil|ServerAdapterExecutable
 ---@field options nil|ServerOptions
 
+
+---@class DapPipeOptions
+---@field timeout? integer max amount of time in ms to wait between spawning the executable and connecting. This gives the executable time to create the pipe. Defaults to 5000
+
 ---@class PipeAdapter : Adapter
 ---@field type "pipe"
 ---@field pipe string absolute path to the pipe or ${pipe} to use random tmp path
 ---@field executable? ServerAdapterExecutable
+---@field options? DapPipeOptions
 
 ---@class ServerAdapterExecutable
 ---@field command string

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -1252,7 +1252,10 @@ function Session.pipe(adapter, opts, on_connect)
     log.debug(
       "Debug adapter server executable started with pipe " .. adapter.pipe)
     -- The adapter should create the pipe
-    vim.wait(5000, function()
+
+    local adapter_opts = adapter.options or {}
+    local timeout = adapter_opts.timeout or 5000
+    vim.wait(timeout, function()
       return uv.fs_stat(adapter.pipe) ~= nil
     end)
   end


### PR DESCRIPTION
5000ms can be too short.
See https://github.com/mfussenegger/nvim-dap/discussions/1147
