### PR TITLE
fix absent column in dap response causes -> attempt to perform arithmetic on local 'column' (a nil value)

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -406,7 +406,7 @@ local function jump_to_location(bufnr, line, column, switchbuf, filetype)
   -- vscode-go sends columns with 0
   -- That would cause a "Column value outside range" error calling nvim_win_set_cursor
   -- nvim-dap says "columnsStartAt1 = true" on initialize :/
-  if column == 0 then
+  if column == nil or column == 0 then
     column = 1
   end
   local cur_buf = api.nvim_get_current_buf()


### PR DESCRIPTION
```
...ppData/Local/nvim-data/lazy/nvim-dap/lua/dap/session.lua:377: attempt to perform arithmetic on local 'column' (a nil value)
stack traceback:
^I...ppData/Local/nvim-data/lazy/nvim-dap/lua/dap/session.lua:377: in function 'set_cursor'                                                                                                                                                                                   
^I...ppData/Local/nvim-data/lazy/nvim-dap/lua/dap/session.lua:425: in function 'fn'                                                                                                                                                                                           
^I...ppData/Local/nvim-data/lazy/nvim-dap/lua/dap/session.lua:499: in function 'jump_to_location'                                                                                                                                                                             
^I...ppData/Local/nvim-data/lazy/nvim-dap/lua/dap/session.lua:566: in function 'jump_to_frame'                                                                                                                                                                                
^I...ppData/Local/nvim-data/lazy/nvim-dap/lua/dap/session.lua:719: in function <...ppData/Local/nvim-data/lazy/nvim-dap/lua/dap/session.lua:650>                                                                                                                              
^I[C]: in function 'xpcall'
^I.../AppData/Local/nvim-data/lazy/nvim-dap/lua/dap/async.lua:12: in function <.../AppData/Local/nvim-data/lazy/nvim-dap/lua/dap/async.lua:11>                                                                                                                                
Press ENTER or type command to continue

```

```
> lldb --version
lldb version 19.0.0git (https://github.com/llvm/llvm-project.git revision 26852565a5f609e6b466f43c2f690ce3047d04c7)
  clang revision 26852565a5f609e6b466f43c2f690ce3047d04c7
  llvm revision 26852565a5f609e6b466f43c2f690ce3047d04c7
```

# FOLLOWING IS A SNIPPET FROM SESSION DEBUG LOG

### SESSION INIT

```
[ DEBUG ] 2024-04-21T23:52:25Z+0200 ] ...ppData/Local/nvim-data/lazy/nvim-dap/lua/dap/session.lua:1376 ]	"Spawning debug adapter"	{
  command = "D:\\__OpenSource\\llvm-project-install-target\\LLVMx64/bin/lldb-dap.exe",
  name = "lldb",
  type = "executable"
}
[ DEBUG ] 2024-04-21T23:52:25Z+0200 ] ...ppData/Local/nvim-data/lazy/nvim-dap/lua/dap/session.lua:1686 ]	"request"	{
  arguments = {
    adapterID = "nvim-dap",
    clientID = "neovim",
    clientName = "neovim",
    columnsStartAt1 = true,
    linesStartAt1 = true,
    locale = "en_US",
    pathFormat = "path",
    supportsProgressReporting = true,
    supportsRunInTerminalRequest = true,
    supportsStartDebuggingRequest = true,
    supportsVariableType = true
  },
  command = "initialize",
  seq = 1,
  type = "request"
}
[ DEBUG ] 2024-04-21T23:52:25Z+0200 ] ...ppData/Local/nvim-data/lazy/nvim-dap/lua/dap/session.lua:957 ]	4	{
  body = {
    completionTriggerCharacters = { ".", " ", "\t" },
    exceptionBreakpointFilters = { {
        default = false,
        filter = "cpp_catch",
        label = "C++ Catch"
      }, {
        default = false,
        filter = "cpp_throw",
        label = "C++ Throw"
      }, {
        default = false,
        filter = "objc_catch",
        label = "Objective-C Catch"
      }, {
        default = false,
        filter = "objc_throw",
        label = "Objective-C Throw"
      }, {
        default = false,
        filter = "swift_catch",
        label = "Swift Catch"
      }, {
        default = false,
        filter = "swift_throw",
        label = "Swift Throw"
      } },
    supportTerminateDebuggee = true,
    supportsCompletionsRequest = true,
    supportsConditionalBreakpoints = true,
    supportsConfigurationDoneRequest = true,
    supportsDataBreakpoints = true,
    supportsDelayedStackTraceLoading = true,
    supportsDisassembleRequest = true,
    supportsEvaluateForHovers = true,
    supportsExceptionInfoRequest = true,
    supportsExceptionOptions = true,
    supportsFunctionBreakpoints = true,
    supportsGotoTargetsRequest = false,
    supportsHitConditionalBreakpoints = true,
    supportsLoadedSourcesRequest = false,
    supportsLogPoints = true,
    supportsModulesRequest = true,
    supportsProgressReporting = true,
    supportsRestartFrame = false,
    supportsRestartRequest = true,
    supportsRunInTerminalRequest = true,
    supportsSetVariable = true,
    supportsStepBack = false,
    supportsStepInTargetsRequest = false,
    supportsValueFormattingOptions = true
  },
  command = "initialize",
  request_seq = 1,
  seq = 0,
  success = true,
  type = "response"
}
```

### RESPONSE THAT CAUSED EXCEPTION 

```
[ DEBUG ] 2024-04-21T23:54:11Z+0200 ] ...ppData/Local/nvim-data/lazy/nvim-dap/lua/dap/session.lua:1686 ]	"request"	{
  arguments = {
    threadId = 3148
  },
  command = "stackTrace",
  seq = 9,
  type = "request"
}
[ DEBUG ] 2024-04-21T23:54:11Z+0200 ] ...ppData/Local/nvim-data/lazy/nvim-dap/lua/dap/session.lua:957 ]	4	{
  body = {
    stackFrames = { {
        id = 524288,
        instructionPointerReference = "0x7FF6459DB8FC",
        line = 8,
        name = "main",
        source = {
          name = "a.cpp",
          path = "D:\\MyProjects\\cpp-test\\ninjatest\\a.cpp"
        }
      }, {
        id = 524289,
        instructionPointerReference = "0x7FF6459EBC6C",
        line = 288,
        name = "static int __scrt_common_main_seh()",
        source = {
          name = "exe_common.inl",
          path = "D:\\a\\_work\\1\\s\\src\\vctools\\crt\\vcstartup\\src\\startup\\exe_common.inl"
        }
      }, {
        column = 0,
        id = 524290,
        instructionPointerReference = "0x7FFCDA56257D",
        line = 0,
        name = "BaseThreadInitThunk",
        presentationHint = "subtle"
      }, {
        column = 0,
        id = 524291,
        instructionPointerReference = "0x7FFCDB8CAA48",
        line = 0,
        name = "RtlUserThreadStart",
        presentationHint = "subtle"
      } },
    totalFrames = 4
  },
  command = "stackTrace",
  request_seq = 9,
  seq = 0,
  success = true,
  type = "response"
}
```

