### PR TITLE
Close stdio handles after process exits

### DIFF
--- a/tests/debugpy_spec.lua
+++ b/tests/debugpy_spec.lua
@@ -86,9 +86,7 @@ describe('dap with debugpy', function()
     -- ensure `called_with` below passes
     config.dummy_payload = dummy_payload
 
-    it('passed cwd to adapter process', function()
-      luassert.spy(launch).was.called_with(dap.adapters.python, config, { cwd = venv_dir, filetype = 'python' })
-    end)
+    luassert.spy(launch).was.called_with(dap.adapters.python, config, { cwd = venv_dir, filetype = 'python' })
   end)
 end)
 vim.fn.delete(venv_dir, 'rf')


### PR DESCRIPTION
Some debug adapters don't like it if dap closes stdin eagerly.
An example is gdb: https://github.com/mfussenegger/nvim-dap/issues/1206
