### PR TITLE
Set nowrap in repl and float windows

### DIFF
--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -63,6 +63,11 @@ local function new_win(buf, winopts, wincmd)
   api.nvim_command(wincmd or 'belowright split')
   local win = api.nvim_get_current_win()
   api.nvim_win_set_buf(win, buf)
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.wo[win][0].wrap = false
+  else
+    vim.wo[win].wrap = false
+  end
   ui.apply_winopts(win, winopts)
   return win
 end

--- a/lua/dap/ui/widgets.lua
+++ b/lua/dap/ui/widgets.lua
@@ -27,17 +27,22 @@ end
 
 function M.new_cursor_anchored_float_win(buf)
   vim.bo[buf].bufhidden = "wipe"
-  vim.bo[buf].filetype = "dap-float"
   local opts = vim.lsp.util.make_floating_popup_options(50, 30, {border = 'single'})
   local win = api.nvim_open_win(buf, true, opts)
-  vim.wo[win].scrolloff = 0
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.wo[win][0].scrolloff = 0
+    vim.wo[win][0].wrap = false
+  else
+    vim.wo[win].scrolloff = 0
+    vim.wo[win].wrap = false
+  end
+  vim.bo[buf].filetype = "dap-float"
   return win
 end
 
 
 function M.new_centered_float_win(buf)
   vim.bo[buf].bufhidden = "wipe"
-  vim.bo[buf].filetype = "dap-float"
   local columns = vim.o.columns
   local lines = vim.o.lines
   local width = math.floor(columns * 0.9)
@@ -51,7 +56,16 @@ function M.new_centered_float_win(buf)
     height = height,
     border = 'single',
   }
-  return api.nvim_open_win(buf, true, opts)
+  local win = api.nvim_open_win(buf, true, opts)
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.wo[win][0].scrolloff = 0
+    vim.wo[win][0].wrap = false
+  else
+    vim.wo[win].scrolloff = 0
+    vim.wo[win].wrap = false
+  end
+  vim.bo[buf].filetype = "dap-float"
+  return win
 end
 
 


### PR DESCRIPTION
Seems to work better for variables where the `tostring` implementation
is long and repeats information also available in the structure display.
