### PR TITLE
Add ability to specify what adapter a type corresponds to from launch.json

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -333,7 +333,7 @@ function to support json5 features like trailing comma.
 (One json5 parser implementation is https://github.com/Joakker/lua-json5)
 
 
-load_launchjs({path}, {type_to_filetypes})        *dap.ext.vscode.load_launchjs*
+load_launchjs({path}, {type_to_filetypes}, {type_to_adapter})        *dap.ext.vscode.load_launchjs*
 
   Parses a JSON file at {path} and adds the entries to `dap.configurations`.
   Configurations are overwritten by name, so if filetype and name matches a
@@ -348,6 +348,11 @@ load_launchjs({path}, {type_to_filetypes})        *dap.ext.vscode.load_launchjs*
                            one or more filetypes.
                            By default, the `type` values in `launch.json` will
                            be used as filetypes verbatim.
+
+      {type_to_adapter}  A table mapping `type` values in `launch.json` to
+                         a defined adapter.
+                         By default, the `type` values in `launch.json` will
+                         be used to match adapters verbatim.
 
 An example `launch.json` might look like this:
 

--- a/lua/dap/ext/vscode.lua
+++ b/lua/dap/ext/vscode.lua
@@ -4,6 +4,7 @@ local M = {}
 
 M.json_decode = vim.json.decode
 M.type_to_filetypes = {}
+M.type_to_adapter = {}
 
 
 ---@class dap.vscode.launch.Input
@@ -176,8 +177,9 @@ end
 
 
 --- Extends dap.configurations with entries read from .vscode/launch.json
-function M.load_launchjs(path, type_to_filetypes)
+function M.load_launchjs(path, type_to_filetypes, type_to_adapter)
   type_to_filetypes = vim.tbl_extend('keep', type_to_filetypes or {}, M.type_to_filetypes)
+  type_to_adapter = vim.tbl_extend('keep', type_to_adapter or {}, M.type_to_adapter)
   local resolved_path = path or (vim.fn.getcwd() .. '/.vscode/launch.json')
   if not vim.loop.fs_stat(resolved_path) then
     return
@@ -196,6 +198,7 @@ function M.load_launchjs(path, type_to_filetypes)
     assert(config.type, "Configuration in launch.json must have a 'type' key")
     assert(config.name, "Configuration in launch.json must have a 'name' key")
     local filetypes = type_to_filetypes[config.type] or { config.type, }
+    config.type = type_to_adapter[config.type] or config.type
     for _, filetype in pairs(filetypes) do
       local dap_configurations = dap.configurations[filetype] or {}
       for i, dap_config in pairs(dap_configurations) do

--- a/tests/ext_vscode_spec.lua
+++ b/tests/ext_vscode_spec.lua
@@ -15,6 +15,15 @@ describe('dap.ext.vscode', function()
     assert.are.same({ { type = 'bar', request = 'attach', name = "bar test" }, }, dap.configurations.cpp)
   end)
 
+  it('can load launch.json file and map type to adapter', function()
+    local dap = require('dap')
+    vscode.load_launchjs('tests/launch.json', { bar = { 'c', 'cpp' } }, { bar = "foo" })
+    assert.are.same(3, vim.tbl_count(dap.configurations))
+    assert.are.same({ { type = 'java', request = 'launch', name = "java test" }, }, dap.configurations.java)
+    assert.are.same({ { type = 'foo', request = 'attach', name = "bar test" }, }, dap.configurations.c)
+    assert.are.same({ { type = 'foo', request = 'attach', name = "bar test" }, }, dap.configurations.cpp)
+  end)
+
   it('supports promptString input', function()
     local prompt
     local default


### PR DESCRIPTION
I use [nvim-dap-vscode-js](https://github.com/mxsdev/nvim-dap-vscode-js) to debug javascript and typescript files. It sets up adapters automatically with various names such as `pwa-node`.

In launch.json files, the "type" that is put for debugging javascript and typescript files I've found to usually be set to "node". Since right now the type is used to find the adapter by name in nvim-dap, trying to debug using these configs is failing by default since I don't have an adapter named "node". I'm creating this PR to be able to map type from the launch.json configuration to the adapter you would want to use in Neovim.

In my case, with this change I can now do this to load debug options from launch.json and run them successfully.

```lua
  local vs_map = { node = { "javascript", "typescript" } }
  local adapter_map = { node = "pwa-node" }
  require("dap.ext.vscode").load_launchjs(nil, vs_map, adapter_map)
```