### PR TITLE
Add config providers; always load .vscode/launch.json

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -1178,9 +1178,17 @@ You could also customize the buffer and window creation using a low-level builde
     .build()
 <
 
-
 ==============================================================================
 EXTENSIONS API                                                *dap-extensions*
+
+nvim-dap provides extension points for plugins:
+
+- |dap-listeners|
+- |dap-providers|
+
+
+==============================================================================
+LISTENERS EXTENSIONS API                                       *dap-listeners*
 
 
 nvim-dap supports subscribing and listening to all responses or events that a
@@ -1231,6 +1239,59 @@ For events, the listeners are called with two arguments:
 
 1. The session
 2. The event payload
+
+
+==============================================================================
+PROVIDERS EXTENSIONS API                                       *dap-providers*
+
+==============================================================================
+CONFIG PROVIDERS EXTENSIONS API                         *dap-providers-configs*
+
+If a user starts a debug session via |dap.continue()|, nvim-dap looks for
+a suitable configuration (|dap-configuration|) to use.
+
+To do so it uses so called configuration providers registered in a
+`dap.providers.configs` table.
+
+Plugins can extend this table with additional config providers.
+
+There are two providers built-in:
+
+- `dap.global` - looks for configuration entries in
+  `dap.configurations.<filetype>`
+
+- `dap.launch.json` - looks for configuration entries in a
+  `.vscode/launch.json` file.
+
+
+The key for the table is a `plugin-id`. Plugins should use their plugin name.
+Do _not_ use the `dap.` namespace. It is reserved for nvim-dap itself.
+
+The value for the table is a function that takes a buffer number as parameter
+and must return |dap-configuration| entries as list.
+
+An example:
+
+>lua
+  local dap = require("dap")
+  dap.providers.configs["mydummy_provider"] = function(bufnr)
+    return {
+      {
+        name = "This config always shows up",
+        type = "gdb",
+        request = "launch",
+        program = "/usr/bin/zig",
+        args = {"run", "${file}"},
+        cwd = "${workspaceFolder}",
+      },
+    }
+  end
+<
+
+To support async operations, the config providers functions are called
+within a coroutine and they can also return a `thread` which must be suspended
+and which will be resumed at most once and must then yield the configurations
+as list.
 
 ==============================================================================
 UTILS API                                                          *dap-utils*

--- a/lua/dap/ext/vscode.lua
+++ b/lua/dap/ext/vscode.lua
@@ -174,13 +174,12 @@ function M._load_json(jsonstr)
   return configs
 end
 
-
---- Extends dap.configurations with entries read from .vscode/launch.json
-function M.load_launchjs(path, type_to_filetypes)
-  type_to_filetypes = vim.tbl_extend('keep', type_to_filetypes or {}, M.type_to_filetypes)
+---@param path string?
+---@return Configuration[]
+function M.getconfigs(path)
   local resolved_path = path or (vim.fn.getcwd() .. '/.vscode/launch.json')
   if not vim.loop.fs_stat(resolved_path) then
-    return
+    return {}
   end
   local lines = {}
   for line in io.lines(resolved_path) do
@@ -189,7 +188,14 @@ function M.load_launchjs(path, type_to_filetypes)
     end
   end
   local contents = table.concat(lines, '\n')
-  local configurations = M._load_json(contents)
+  return M._load_json(contents)
+end
+
+
+--- Extends dap.configurations with entries read from .vscode/launch.json
+function M.load_launchjs(path, type_to_filetypes)
+  type_to_filetypes = vim.tbl_extend('keep', type_to_filetypes or {}, M.type_to_filetypes)
+  local configurations = M.getconfigs(path)
 
   assert(configurations, "launch.json must have a 'configurations' key")
   for _, config in ipairs(configurations) do


### PR DESCRIPTION
- Introduces a dap.providers.configs table which plugins can extend to
  add additional sources for dynamic configuration generation

- Implements the two built-in configuration sources as providers

- `.vscode/launch.json` files are now loaded automatically by one of
  these providers. The entries from the file always display even if the
  type doesn't match the current filetype. This gets rid of the
  `type_to_filetypes` mapping requirements.

Closes:
- https://github.com/mfussenegger/nvim-dap/issues/1065
- https://github.com/mfussenegger/nvim-dap/issues/1087
- https://github.com/mfussenegger/nvim-dap/issues/1226