### PR TITLE
Remove executable from adapter when request type is attach

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -1122,6 +1122,15 @@ function M.attach(adapter, config, opts)
     return
   end
   assert(adapter.port, 'Adapter used with attach must have a port property')
+
+  -- Clear executable from adapter when the request is to attach.
+  -- Spawning a new executable is likely the wrong thing to do.
+  if config.request == 'attach' and adapter.executable then
+    adapter = vim.deepcopy(adapter)
+    ---@diagnostic disable-next-line: inject-field
+    adapter.executable = nil
+  end
+
   local s
   s = require('dap.session'):connect(adapter, opts, function(err)
     if err then


### PR DESCRIPTION
Related to https://github.com/leoluz/nvim-dap-go/issues/35. When attempting to attach to a remote dlv process, the nvim-dap-go plugin would attempt to launch an executable on the same port it was supposed to connect to. This would fail and would cause the plugin not to attach to the existingøØrt.

This is because nvim-dap-go switched to using the included adapter and the adapter does not check if the request is launch or attach before attempting to launch the dlv process.

This is fixed by removing executable from the adapter if the config uses attach since an attach request shouldn't be launching an executable anyway.