### PR TITLE
Fix only general error message is shown when launch.json is invalid

### DIFF
--- a/lua/dap/ext/vscode.lua
+++ b/lua/dap/ext/vscode.lua
@@ -147,8 +147,7 @@ end
 function M._load_json(jsonstr)
   local ok, data = pcall(M.json_decode, jsonstr)
   if not ok then
-    notify("Error parsing launch.json: " .. jsonstr, vim.log.levels.ERROR)
-    return {}
+    error("Error parsing launch.json: " .. data)
   end
 
   local inputs = create_inputs(data.inputs or {})

--- a/lua/dap/ext/vscode.lua
+++ b/lua/dap/ext/vscode.lua
@@ -145,7 +145,12 @@ end
 
 
 function M._load_json(jsonstr)
-  local data = assert(M.json_decode(jsonstr), "launch.json must contain a JSON object")
+  local ok, data = pcall(M.json_decode, jsonstr)
+  if not ok then
+    notify("Error parsing launch.json: " .. jsonstr, vim.log.levels.ERROR)
+    return {}
+  end
+
   local inputs = create_inputs(data.inputs or {})
   local has_inputs = next(inputs) ~= nil
 

--- a/lua/dap/ext/vscode.lua
+++ b/lua/dap/ext/vscode.lua
@@ -149,7 +149,7 @@ function M._load_json(jsonstr)
   if not ok then
     error("Error parsing launch.json: " .. data)
   end
-
+  assert(type(data) == "table", "launch.json must contain a JSON object")
   local inputs = create_inputs(data.inputs or {})
   local has_inputs = next(inputs) ~= nil
 


### PR DESCRIPTION
When launch.json has invalid encoding/bom launch.json can not be parsed, but it seems that assert does not catches it, so there is a general error message about can not parsing the json, instead of the message that there is some kind of problem with launch.json

To reproduce (tested on Linux):
```
:set ff=unix
:set bomb
```

This PR fixes this behaviour. Currently it also shows the whole launch.json, so the `<feff>` is very telling. If it is too much I can revert to the original message. Maybe extending it with a hint that BOM might be the source of the error.