### PR TITLE
Add utils.pick_process_by_name()

### DIFF
--- a/lua/dap/utils.lua
+++ b/lua/dap/utils.lua
@@ -317,7 +317,7 @@ end
 --     pid = require("dap.utils").pick_process_by_name
 -- },
 --- </pre>
----@return thread|string|dap.Abort
+---@return string|dap.Abort
 function M.pick_process_by_name()
     local process = vim.fn.input('Process to attach: ')
     if vim.fn.has('win32') == 1 then


### PR DESCRIPTION
Hi!

My approach to manage the PID picker.
1) Enter the process name to attach
2) pgrep will retrieve the list off matching process and the user can select one of them
3) If none results was found, the user can input one by hand

Unfortunately it doesn't support windows because I don't have a proper setup to test it.

Config prompt:
![imagen](https://github.com/user-attachments/assets/b4d683fa-a974-4dda-94da-783db743fa13)
Process name prompt:
![imagen](https://github.com/user-attachments/assets/1651cea1-1e59-4748-9b32-48f9296812e1)
Select PID prompt:
![imagen](https://github.com/user-attachments/assets/9c671c70-7115-44d6-bd22-770262626dfd)
Manual PID prompt:
![imagen](https://github.com/user-attachments/assets/16c0b10e-9a11-4730-a6f7-ade1f5753d11)
Attached:
![imagen](https://github.com/user-attachments/assets/3856f83e-1552-4dbb-91a6-dadd50908d72)