### PR TITLE
Handle disassembly buffer

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -410,7 +410,9 @@ local function jump_to_location(bufnr, line, column, switchbuf, filetype)
   local switchbuf_fn = {}
 
   function switchbuf_fn.uselast()
-    if vim.bo[cur_buf].buftype == '' or vim.bo[cur_buf].filetype == filetype or vim.bo[cur_buf].buftype == 'nofile' then
+    local ok, is_source_buf = pcall(vim.api.nvim_buf_get_var, cur_buf, 'dap_source_buf')
+    is_source_buf = ok and is_source_buf
+    if vim.bo[cur_buf].buftype == '' or vim.bo[cur_buf].filetype == filetype or is_source_buf then
       api.nvim_win_set_buf(cur_win, bufnr)
       set_cursor(cur_win, line, column)
     else

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -410,7 +410,7 @@ local function jump_to_location(bufnr, line, column, switchbuf, filetype)
   local switchbuf_fn = {}
 
   function switchbuf_fn.uselast()
-    if vim.bo[cur_buf].buftype == '' or vim.bo[cur_buf].filetype == filetype then
+    if vim.bo[cur_buf].buftype == '' or vim.bo[cur_buf].filetype == filetype or vim.bo[cur_buf].filetype == 'nofile' then
       api.nvim_win_set_buf(cur_win, bufnr)
       set_cursor(cur_win, line, column)
     else

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -410,7 +410,7 @@ local function jump_to_location(bufnr, line, column, switchbuf, filetype)
   local switchbuf_fn = {}
 
   function switchbuf_fn.uselast()
-    if vim.bo[cur_buf].buftype == '' or vim.bo[cur_buf].filetype == filetype or vim.bo[cur_buf].filetype == 'nofile' then
+    if vim.bo[cur_buf].buftype == '' or vim.bo[cur_buf].filetype == filetype or vim.bo[cur_buf].buftype == 'nofile' then
       api.nvim_win_set_buf(cur_win, bufnr)
       set_cursor(cur_win, line, column)
     else


### PR DESCRIPTION
Fix https://github.com/mfussenegger/nvim-dap/issues/956#issuecomment-1584883229

The disassembly buffer is of the "nofile" type, which has not been handled. This leads to the error "cursor position outside the buffer" when more than two panes opened.

This error can be reproduced using [this Dockerfile](https://github.com/bogdan-nikitin/nvim-dap-956/blob/main/Dockerfile):
1. Run container interactively. Neovim opens with an example file with a breakpoint set
2. Type `:DapContinue`
3. Type `:DapStepInto` few times
4. Assembly will appear in both panes