### PR TITLE
feat: Allow DapToggleBreakpoint for placing conditional breakpoints

### DIFF
--- a/plugin/dap.lua
+++ b/plugin/dap.lua
@@ -17,7 +17,13 @@ cmd('DapSetLogLevel',
 )
 cmd('DapShowLog', 'split | e ' .. vim.fn.stdpath('cache') .. '/dap.log | normal! G', {})
 cmd('DapContinue', function() require('dap').continue() end, { nargs = 0 })
-cmd('DapToggleBreakpoint', function() require('dap').toggle_breakpoint() end, { nargs = 0 })
+cmd('DapToggleBreakpoint',
+  function(opts)
+    local condition = (opts.args ~= "") and opts.args or nil
+    require('dap').toggle_breakpoint(condition)
+  end,
+  { nargs = "*", }
+)
 cmd('DapToggleRepl', function() require('dap.repl').toggle() end, { nargs = 0 })
 cmd('DapStepOver', function() require('dap').step_over() end, { nargs = 0 })
 cmd('DapStepInto', function() require('dap').step_into() end, { nargs = 0 })

--- a/plugin/dap.lua
+++ b/plugin/dap.lua
@@ -20,7 +20,19 @@ cmd('DapContinue', function() require('dap').continue() end, { nargs = 0 })
 cmd('DapToggleBreakpoint',
   function(opts)
     local condition = (opts.args ~= "") and opts.args or nil
-    require('dap').toggle_breakpoint(condition)
+    local bufnr = api.nvim_get_current_buf()
+    local breakpoints = require('dap.breakpoints').get(bufnr)[bufnr]
+    local win = api.nvim_get_current_win()
+    local line = api.nvim_win_get_cursor(win)[1]
+    local old;
+    for _, bp in ipairs(breakpoints) do
+      if bp.line == line then
+        old = bp
+        break
+      end
+    end
+    local replace_old = old and (old.condition ~= condition)
+    require('dap').toggle_breakpoint(condition, nil, nil, replace_old)
   end,
   { nargs = "*", }
 )


### PR DESCRIPTION
Hi,

I was looking for a way of creating conditional breakpoints through user commands and the easiest solution is to allow `DapToggleBreakpoint` to take additional args and pass them all as condition into `dap.toggle_breakpoint`. Since user can place two types of BPs now, I also made sure said command only removes BP when invoked with the same condition, in other cases it replaces the BP which is intuitive when you wish to change the condition or turn un-conditional BP into the conditional one.

The only problem I'm a bit concerned about is that when you have a conditional BP, calling `:DapToggleBreakpoint` (without args) would change it into un-conditional one (instead of removing) which might be a bit confusing. I could adjust this so calling command without args at existing BP would **always** disable it, no matter condition. But I think this is just a minor inconvenience and depends on preference.

Cheers!

Relates: https://github.com/mfussenegger/nvim-dap/discussions/670

https://github.com/user-attachments/assets/48b61d29-d815-4d4b-b49c-e4538a3be889



