### PR TITLE
Fixing error when evaluating code and resp.variablesReference is nil

### DIFF
--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -162,7 +162,7 @@ local function evaluate_handler(err, resp)
   end
   local layer = ui.layer(repl.buf)
   local attributes = (resp.presentationHint or {}).attributes or {}
-  if resp.variablesReference > 0 or vim.tbl_contains(attributes, 'rawString') then
+  if (resp.variablesReference ~= nil and resp.variablesReference > 0) or vim.tbl_contains(attributes, 'rawString') then
     local spec = require('dap.entity').variable.tree_spec
     local tree = ui.new_tree(spec)
     -- tree.render would "append" twice, once for the top element and once for the children


### PR DESCRIPTION
When `resp.variablesReference` the following error happens:
![SCR-20240904-ttti](https://github.com/user-attachments/assets/2b8b9d78-341e-4691-9cfd-7d5355604b51)

Checking if resp.variablesReference is not nil solves the issue.

This error is also easily reproducible with the following lua code:
```lua
({}).anything > 0
```
![SCR-20240907-pnns](https://github.com/user-attachments/assets/8047868f-1a26-43cd-9753-f9cc4a0b6a72)