### PR TITLE
Always inherit environment when launching external terminal

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -118,11 +118,15 @@ local function launch_external_terminal(env, terminal, args)
   local full_args = {}
   vim.list_extend(full_args, terminal.args or {})
   vim.list_extend(full_args, args)
-  local env_formatted = {}
-  -- Copy environment, prefer vars set by client
-  for k, v in pairs(env and vim.tbl_extend('keep', env, vim.fn.environ()) or {}) do
-    if k:find "^[^=]*$" then -- correct variable?
-      env_formatted[#env_formatted+1] = k.."="..tostring(v)
+  -- Initializing to nil is important so environment is inherited by the terminal
+  local env_formatted = nil
+  if env then
+    env_formatted = {}
+    -- Copy environment, prefer vars set by client
+    for k, v in pairs(vim.tbl_extend('keep', env, vim.fn.environ())) do
+      if k:find "^[^=]*$" then -- correct variable?
+        env_formatted[#env_formatted+1] = k.."="..tostring(v)
+      end
     end
   end
   local opts = {


### PR DESCRIPTION
This was discussed on the closed issue #1317 (from [this comment](https://github.com/mfussenegger/nvim-dap/issues/1317#issuecomment-2373653869)).

#1318 was merged in August and propagated environment to the launched external terminal, but it seemed to propagate the environment VIM was started with **if and only if** an environment was set somewhere in the configuration and passed to the `launch_external_terminal` function.

This had the side effect, under some configuration, that the launched external terminal have an empty environment.

This pull request changed the logic when merging VIM environment and passed environment to always include the environment VIM was started with.

--

I am quite unable to determine if this could have side effects or if the fact that the parent environment not being inherited by the external terminal is working as intended, so do not hesitate to tell me if that is the case, for some reason.