### PR TITLE
Fix compare-with-nil error for resp.variablesReference

### DIFF
--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -162,7 +162,7 @@ local function evaluate_handler(err, resp)
   end
   local layer = ui.layer(repl.buf)
   local attributes = (resp.presentationHint or {}).attributes or {}
-  if resp.variablesReference > 0 or vim.tbl_contains(attributes, 'rawString') then
+  if (resp.variablesReference and (resp.variablesReference > 0)) or vim.tbl_contains(attributes, 'rawString') then
     local spec = require('dap.entity').variable.tree_spec
     local tree = ui.new_tree(spec)
     -- tree.render would "append" twice, once for the top element and once for the children


### PR DESCRIPTION
In case the `resp` variable has no `variablesReference` field, the comparison `resp.variablesReference > 0` will fail.

This commit add the is-not-nil check for `resp.variablesReference`.