### PR TITLE
Add filter options to fix new unity debugger

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -147,9 +147,9 @@ M.defaults = setmetatable(
   {
     fallback = {
       exception_breakpoints = 'default',
-      ---@type string|nil
+      ---@type table[]|nil
       exception_options = nil,
-      ---@type string|nil
+      ---@type table[]|nil
       exception_filter_options = nil,
 
       ---@type "statement"|"line"|"instruction"

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -1000,7 +1000,7 @@ function Session:set_exception_breakpoints(filters, exceptionOptions, filterOpti
   --- exceptionOptions: exceptionOptions?: ExceptionOptions[] (https://microsoft.github.io/debug-adapter-protocol/specification#Types_ExceptionOptions)
   self:request(
     'setExceptionBreakpoints',
-    { filters = filters, exceptionOptions = exceptionOptions, filterOptions },
+    { filters = filters, exceptionOptions = exceptionOptions, filterOptions = filterOptions },
     function(err, _)
       if err then
         utils.notify('Error setting exception breakpoints: ' .. utils.fmt_error(err), vim.log.levels.ERROR)

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -316,7 +316,7 @@ function Session:event_initialized()
   local bps = breakpoints.get()
   self:set_breakpoints(bps, function()
     if self.capabilities.exceptionBreakpointFilters then
-      self:set_exception_breakpoints(dap().defaults[self.config.type].exception_breakpoints, nil, on_done)
+      self:set_exception_breakpoints(dap().defaults[self.config.type].exception_breakpoints, nil, nil, on_done)
     else
       on_done()
     end

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -961,7 +961,7 @@ do
   end
 end
 
-function Session:set_exception_breakpoints(filters, exceptionOptions, on_done)
+function Session:set_exception_breakpoints(filters, exceptionOptions, filterOptions, on_done)
   if not self.capabilities.exceptionBreakpointFilters then
     utils.notify("Debug adapter doesn't support exception breakpoints", vim.log.levels.INFO)
     return
@@ -991,12 +991,16 @@ function Session:set_exception_breakpoints(filters, exceptionOptions, on_done)
     return
   end
 
+  if not filterOptions then
+    filterOptions = {}
+  end
+
   -- setExceptionBreakpoints (https://microsoft.github.io/debug-adapter-protocol/specification#Requests_SetExceptionBreakpoints)
   --- filters: string[]
   --- exceptionOptions: exceptionOptions?: ExceptionOptions[] (https://microsoft.github.io/debug-adapter-protocol/specification#Types_ExceptionOptions)
   self:request(
     'setExceptionBreakpoints',
-    { filters = filters, exceptionOptions = exceptionOptions },
+    { filters = filters, exceptionOptions = exceptionOptions, filterOptions },
     function(err, _)
       if err then
         utils.notify('Error setting exception breakpoints: ' .. utils.fmt_error(err), vim.log.levels.ERROR)


### PR DESCRIPTION
As mentioned, [here](https://github.com/mfussenegger/nvim-dap/discussions/815), the new Unity debugger doesn't work without filterOptions passed for setBreakPointExceptions. This PR fixes that by including filterOptions. This enables use of the Unity debugger, and I believe shouldn't affect other adapters since filterOptions is always nil in session.lua.

Tested with Unity debugger, codelldb, and debugpy.