### PR TITLE
Handle absent `allThreadsContinued` as true

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -1966,7 +1966,7 @@ end
 
 ---@param event dap.ContinuedEvent
 function Session:event_continued(event)
-  if event.allThreadsContinued then
+  if event.allThreadsContinued == nil or event.allThreadsContinued == true then
     for _, t in pairs(self.threads) do
       t.stopped = false
     end


### PR DESCRIPTION
See clarification: https://github.com/microsoft/debug-adapter-protocol/pull/514
