### PR TITLE
Fix errors on nil column send in the dap frame

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -420,7 +420,8 @@ local function jump_to_location(bufnr, line, column, switchbuf, filetype)
   -- vscode-go sends columns with 0
   -- That would cause a "Column value outside range" error calling nvim_win_set_cursor
   -- nvim-dap says "columnsStartAt1 = true" on initialize :/
-  if column == 0 then
+  -- Also lldb can sometimes send nil as the column
+  if column == 0 or column == nil then
     column = 1
   end
   local cur_buf = api.nvim_get_current_buf()


### PR DESCRIPTION
It's possible for lldb dap to send nil as the column. Especially common with target.process.thread.step-in-avoid-nodebug 0 where after stepping finally finds a valid source first call is with a nil column leading to nvim lua errors due to arithmetic on nil.