### PR TITLE
Add SetExceptionBreakpoint Optional Args

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -780,7 +780,8 @@ clear_breakpoints()                                   *dap.clear_breakpoints()*
 
     Removes all breakpoints
 
-set_exception_breakpoints({filters}, {exceptionOptions})
+set_exception_breakpoints({filters}, {exceptionOptions},
+{filterOptions})
                                               *dap.set_exception_breakpoints()*
 
     Sets breakpoints on exceptions filtered by `filters`. If `filters` is not
@@ -796,6 +797,9 @@ set_exception_breakpoints({filters}, {exceptionOptions})
                            used.
         {exceptionOptions} ExceptionOptions[]?
                            (https://microsoft.github.io/debug-adapter-protocol/specification#Types_ExceptionOptions)
+
+        {filterOptions} ExceptionFilterOptions[]?
+                           (https://microsoft.github.io/debug-adapter-protocol/specification#Types_ExceptionFilterOptions)
 
     >lua
         -- Ask user to stop on which kinds of exceptions

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -147,6 +147,11 @@ M.defaults = setmetatable(
   {
     fallback = {
       exception_breakpoints = 'default';
+      ---@type table[]|nil
+      exception_options = nil;
+      ---@type table[]|nil
+      exception_filter_options = nil;
+
       ---@type "statement"|"line"|"instruction"
       stepping_granularity = 'statement';
 
@@ -952,14 +957,14 @@ end
 -- setExceptionBreakpoints (https://microsoft.github.io/debug-adapter-protocol/specification#Requests_SetExceptionBreakpoints)
 --- filters: string[]
 --- exceptionOptions: exceptionOptions?: ExceptionOptions[] (https://microsoft.github.io/debug-adapter-protocol/specification#Types_ExceptionOptions)
-function M.set_exception_breakpoints(filters, exceptionOptions)
+--- filterOptions: filterOptions?: ExceptionFilterOptions[] (https://microsoft.github.io/debug-adapter-protocol/specification#Types_ExceptionFilterOptions)
+function M.set_exception_breakpoints(filters, exceptionOptions, filterOptions)
   if session then
-    session:set_exception_breakpoints(filters, exceptionOptions)
+    session:set_exception_breakpoints(filters, exceptionOptions, filterOptions)
   else
     notify('Cannot set exception breakpoints: No active session!', vim.log.levels.INFO)
   end
 end
-
 
 function M.run_to_cursor()
   local lsession = session

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -316,7 +316,11 @@ function Session:event_initialized()
   local bps = breakpoints.get()
   self:set_breakpoints(bps, function()
     if self.capabilities.exceptionBreakpointFilters then
-      self:set_exception_breakpoints(dap().defaults[self.config.type].exception_breakpoints, nil, nil, on_done)
+      self:set_exception_breakpoints(
+        dap().defaults[self.config.type].exception_breakpoints,
+        dap().defaults[self.config.type].exception_options,
+        dap().defaults[self.config.type].exception_filter_options,
+        on_done)
     else
       on_done()
     end
@@ -991,13 +995,15 @@ function Session:set_exception_breakpoints(filters, exceptionOptions, filterOpti
     return
   end
 
-  if not filterOptions then
-    filterOptions = {}
+  if filterOptions and not self.capabilities.supportsExceptionFilterOptions then
+    utils.notify('Debug adapter does not support FilterOptions', vim.log.levels.INFO)
+    return
   end
 
   -- setExceptionBreakpoints (https://microsoft.github.io/debug-adapter-protocol/specification#Requests_SetExceptionBreakpoints)
   --- filters: string[]
   --- exceptionOptions: exceptionOptions?: ExceptionOptions[] (https://microsoft.github.io/debug-adapter-protocol/specification#Types_ExceptionOptions)
+  --- filterOptions: filterOptions?: ExceptionFilterOptions[] (https://microsoft.github.io/debug-adapter-protocol/specification#Types_ExceptionFilterOptions)
   self:request(
     'setExceptionBreakpoints',
     { filters = filters, exceptionOptions = exceptionOptions, filterOptions = filterOptions },

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -1000,7 +1000,7 @@ function Session:set_exception_breakpoints(filters, exceptionOptions, filterOpti
   --- exceptionOptions: exceptionOptions?: ExceptionOptions[] (https://microsoft.github.io/debug-adapter-protocol/specification#Types_ExceptionOptions)
   self:request(
     'setExceptionBreakpoints',
-    { filters = filters, exceptionOptions = exceptionOptions, filterOptions },
+    { filters = filters, exceptionOptions = exceptionOptions, filterOptions = filterOptions },
     function(err, _)
       if err then
         utils.notify('Error setting exception breakpoints: ' .. utils.fmt_error(err), vim.log.levels.ERROR)

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -316,7 +316,7 @@ function Session:event_initialized()
   local bps = breakpoints.get()
   self:set_breakpoints(bps, function()
     if self.capabilities.exceptionBreakpointFilters then
-      self:set_exception_breakpoints(dap().defaults[self.config.type].exception_breakpoints, nil, on_done)
+      self:set_exception_breakpoints(dap().defaults[self.config.type].exception_breakpoints, nil, nil, on_done)
     else
       on_done()
     end

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -961,7 +961,7 @@ do
   end
 end
 
-function Session:set_exception_breakpoints(filters, exceptionOptions, on_done)
+function Session:set_exception_breakpoints(filters, exceptionOptions, filterOptions, on_done)
   if not self.capabilities.exceptionBreakpointFilters then
     utils.notify("Debug adapter doesn't support exception breakpoints", vim.log.levels.INFO)
     return
@@ -991,12 +991,16 @@ function Session:set_exception_breakpoints(filters, exceptionOptions, on_done)
     return
   end
 
+  if not filterOptions then
+    filterOptions = {}
+  end
+
   -- setExceptionBreakpoints (https://microsoft.github.io/debug-adapter-protocol/specification#Requests_SetExceptionBreakpoints)
   --- filters: string[]
   --- exceptionOptions: exceptionOptions?: ExceptionOptions[] (https://microsoft.github.io/debug-adapter-protocol/specification#Types_ExceptionOptions)
   self:request(
     'setExceptionBreakpoints',
-    { filters = filters, exceptionOptions = exceptionOptions },
+    { filters = filters, exceptionOptions = exceptionOptions, filterOptions },
     function(err, _)
       if err then
         utils.notify('Error setting exception breakpoints: ' .. utils.fmt_error(err), vim.log.levels.ERROR)


### PR DESCRIPTION
In nvim-dap, set_exception_breakpoints() exposes one of two optional args in the DAP spec (ExceptionOptions), and it is always nil. This PR adds the other optional arg (ExceptionFilterOptions) and exposes both optional args in defaults.

This allows for non nil definitions of both optional args in the default table if needed/desired, otherwise they will default to nil.

Tested with debugpy, codelldb, and the Unity debugger.