### PR TITLE
Add tagfunc for variables and expressions

### DIFF
--- a/lua/dap/protocol.lua
+++ b/lua/dap/protocol.lua
@@ -139,6 +139,8 @@
 ---@field namedVariables? number
 ---@field indexedVariables? number
 ---@field memoryReference? string
+---@field declarationLocationReference? number
+---@field valueLocationReference? number
 ---@field variables? dap.Variable[] resolved variablesReference. Not part of the spec; added by nvim-dap
 ---@field parent? dap.Variable|dap.Scope injected by nvim-dap
 
@@ -156,6 +158,7 @@
 ---@field namedVariables? number
 ---@field indexedVariables? number
 ---@field memoryReference? string
+---@field valueLocationReference? number
 
 
 ---@class dap.VariablePresentationHint
@@ -359,6 +362,22 @@
 ---@class dap.StartDebuggingRequestArguments
 ---@field configuration table<string, any>
 ---@field request 'launch'|'attach'
+
+
+---@class dap.CompletionsResponse
+---@field targets dap.CompletionItem[]
+
+
+---@class dap.LocationsArguments
+---@field locationReference number
+
+
+---@class dap.LocationsResponse
+---@field source dap.Source
+---@field line integer
+---@field column? integer
+---@field endLine? integer
+---@field endColumn? integer
 
 
 ---@alias dap.CompletionItemType

--- a/lua/dap/ui.lua
+++ b/lua/dap/ui.lua
@@ -414,6 +414,9 @@ end
 ---@type table<number, dap.ui.Layer>
 local layers = {}
 
+--- Return an existing layer
+---
+---@param buf integer
 ---@return nil|dap.ui.Layer
 function M.get_layer(buf)
   return layers[buf]
@@ -424,6 +427,8 @@ end
 ---@field item any
 ---@field context table|nil
 
+--- Returns a layer, creating it if it's missing.
+---@param buf integer
 ---@return dap.ui.Layer
 function M.layer(buf)
   assert(buf, 'Need a buffer to operate on')

--- a/lua/dap/ui/widgets.lua
+++ b/lua/dap/ui/widgets.lua
@@ -147,6 +147,7 @@ M.scopes = {
     dap.listeners.after['event_terminated'][view] = reset_tree
     dap.listeners.after['event_exited'][view] = reset_tree
     local buf = new_buf()
+    vim.bo[buf].tagfunc = "v:lua.require'dap'._tagfunc"
     api.nvim_buf_attach(buf, false, {
       on_detach = function()
         dap.listeners.after['event_terminated'][view] = nil
@@ -372,7 +373,11 @@ do
   end
 
   M.expression = {
-    new_buf = new_buf,
+    new_buf = function()
+      local buf = new_buf()
+      vim.bo[buf].tagfunc = "v:lua.require'dap'._tagfunc"
+      return buf
+    end,
     before_open = function(view)
       view.__expression = vim.fn.expand('<cexpr>')
     end,


### PR DESCRIPTION
Requires debug adapters to set the `valueLocationReference` on evaluate
responses or `declarationLocationReference` on variables
