### PR TITLE
Remove DapLoadLaunchJSON user command

### DIFF
--- a/plugin/dap.lua
+++ b/plugin/dap.lua
@@ -24,7 +24,6 @@ cmd('DapStepInto', function() require('dap').step_into() end, { nargs = 0 })
 cmd('DapStepOut', function() require('dap').step_out() end, { nargs = 0 })
 cmd('DapTerminate', function() require('dap').terminate() end, { nargs = 0 })
 cmd('DapDisconnect', function() require('dap').disconnect({ terminateDebuggee = false }) end, { nargs = 0 })
-cmd('DapLoadLaunchJSON', function() require('dap.ext.vscode').load_launchjs() end, { nargs = 0 })
 cmd('DapRestartFrame', function() require('dap').restart_frame() end, { nargs = 0 })
 
 local function dapnew(args)


### PR DESCRIPTION
With the new config provider model the files are read implicitly
on-demand.
