### PR TITLE
Lower timeout for terminate/disconnect request on nvim exit

### DIFF
--- a/lua/dap/protocol.lua
+++ b/lua/dap/protocol.lua
@@ -310,6 +310,14 @@
 ---@class dap.TerminatedEvent
 ---@field restart? any
 
+---@class dap.TerminateArguments
+---@field restart? boolean
+
+---@class dap.DisconnectArguments
+---@field restart? boolean
+---@field terminateDebuggee? boolean requires `supportTerminateDebuggee` capability
+---@field suspendDebuggee? boolean requires `supportSuspendDebuggee` capability
+
 
 ---@class dap.ThreadEvent
 ---@field reason "started"|"exited"|string


### PR DESCRIPTION
Looks like debug adapters like js-debug-adapter take a bit to process
terminate requests. The `vim.wait(500, ...)` was not enough, leading to
leaked processes.

Lowering the terminate/disconnect request timeout appears to solve the
issue as it leads to the handle getting closed quicker.

Fixes https://github.com/mfussenegger/nvim-dap/issues/1352
