### PR TITLE
Yank expression's evalname automatically to `e` register on regular yank

### DIFF
--- a/lua/dap/_cmds.lua
+++ b/lua/dap/_cmds.lua
@@ -141,4 +141,21 @@ function M.newlaunchjson(args)
 end
 
 
+function M.yank_evalname()
+  if vim.v.event.operator ~= "y" or vim.v.event.visual == true then
+    return
+  end
+  local buf = api.nvim_get_current_buf()
+  local layer = require("dap.ui").get_layer(buf)
+  if not layer then
+    return
+  end
+  local lnum = api.nvim_win_get_cursor(0)[1] - 1
+  local item = (layer.get(lnum) or {}).item
+  if item and item.evaluateName then
+    vim.fn.setreg("e", item.evaluateName)
+  end
+end
+
+
 return M

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -36,6 +36,12 @@ local function new_buf()
   api.nvim_buf_set_keymap(buf, 'n', 'o', "<Cmd>lua require('dap.ui').trigger_actions()<CR>", {})
   api.nvim_buf_set_keymap(buf, 'i', '<up>', "<Cmd>lua require('dap.repl').on_up()<CR>", {})
   api.nvim_buf_set_keymap(buf, 'i', '<down>', "<Cmd>lua require('dap.repl').on_down()<CR>", {})
+  api.nvim_create_autocmd("TextYankPost", {
+    buffer = buf,
+    callback = function()
+      require("dap._cmds").yank_evalname()
+    end,
+  })
   vim.fn.prompt_setprompt(buf, 'dap> ')
   vim.fn.prompt_setcallback(buf, execute)
   if vim.fn.has('nvim-0.7') == 1 then

--- a/lua/dap/ui/widgets.lua
+++ b/lua/dap/ui/widgets.lua
@@ -147,6 +147,12 @@ M.scopes = {
     dap.listeners.after['event_terminated'][view] = reset_tree
     dap.listeners.after['event_exited'][view] = reset_tree
     local buf = new_buf()
+    api.nvim_create_autocmd("TextYankPost", {
+      buffer = buf,
+      callback = function()
+        require("dap._cmds").yank_evalname()
+      end,
+    })
     vim.bo[buf].tagfunc = "v:lua.require'dap'._tagfunc"
     api.nvim_buf_attach(buf, false, {
       on_detach = function()
@@ -376,6 +382,12 @@ do
     new_buf = function()
       local buf = new_buf()
       vim.bo[buf].tagfunc = "v:lua.require'dap'._tagfunc"
+      api.nvim_create_autocmd("TextYankPost", {
+        buffer = buf,
+        callback = function()
+          require("dap._cmds").yank_evalname()
+        end,
+      })
       return buf
     end,
     before_open = function(view)


### PR DESCRIPTION
Easier to use than the "Copy as expression" menu action item, and
shouldn't get in the way either
