### PR TITLE
Allow terminal_win_cmd Callback to Receive Configuration.

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -563,6 +563,9 @@ The configuration values are set via `dap.defaults.fallback` (for global) or
   the integrated terminal. (See |dap-terminal|). Either a string or a function
   that must return a buffer number and a window number of the buffer/window
   for the terminal.
+  When using a function, it receives the current debug configuration as an 
+  argument, allowing for dynamic terminal naming and setup based on the 
+  session's configuration.
 
   Note that extensions like `nvim-dap-ui` use this to control the UI.
   If you customize it, you may break their behavior.

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -150,7 +150,7 @@ M.defaults = setmetatable(
       ---@type "statement"|"line"|"instruction"
       stepping_granularity = 'statement';
 
-      ---@type string|fun(): number bufnr, number|nil win
+      ---@type string|fun(config: dap.Configuration):(integer, integer?)
       terminal_win_cmd = 'belowright new';
       focus_terminal = false;
       auto_continue_if_many_stopped = true;

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -146,8 +146,9 @@ local function launch_external_terminal(env, terminal, args)
 end
 
 
----@param terminal_win_cmd string|fun():integer, integer?
+---@param terminal_win_cmd string|fun(config: dap.Configuration):(integer, integer?)
 ---@param filetype string
+---@param config dap.Configuration
 ---@return integer bufnr, integer? winnr
 local function create_terminal_buf(terminal_win_cmd, filetype, config)
   local cur_win = api.nvim_get_current_win()

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -149,7 +149,7 @@ end
 ---@param terminal_win_cmd string|fun():integer, integer?
 ---@param filetype string
 ---@return integer bufnr, integer? winnr
-local function create_terminal_buf(terminal_win_cmd, filetype)
+local function create_terminal_buf(terminal_win_cmd, filetype, config)
   local cur_win = api.nvim_get_current_win()
   if type(terminal_win_cmd) == "string" then
     api.nvim_command(terminal_win_cmd)
@@ -164,7 +164,7 @@ local function create_terminal_buf(terminal_win_cmd, filetype)
     return bufnr, win
   else
     assert(type(terminal_win_cmd) == "function", "terminal_win_cmd must be a string or a function")
-    return terminal_win_cmd()
+    return terminal_win_cmd(config)
   end
 end
 
@@ -186,7 +186,7 @@ do
       end
     end
     local terminal_win
-    buf, terminal_win = create_terminal_buf(win_cmd, filetype)
+    buf, terminal_win = create_terminal_buf(win_cmd, filetype, config)
     if terminal_win then
       if vim.fn.has('nvim-0.8') == 1 then
         -- older versions don't support the `win` key


### PR DESCRIPTION
First, I want to express my gratitude for your incredible contributions to the Neovim ecosystem.
### Issue
In my current Neovim setup using `nvim-dap` for debugging, I utilize a custom console by defining a `terminal_win_cmd`.  However, with the existing implementation, there's a limitation: the callback function for `terminal_win_cmd` does not receive the debugging session's configuration. This makes it challenging to dynamically set the name of the integrated terminal based on the current debugging session, I need to set a name for the terminal on a multi-session scenario, enabling better picker search by name.

### Changes Made:
Modified the `terminal_win_cmd` callback to accept the `config` parameter. This allows the callback function to access details about the current debugging session, enabling dynamic naming of the integrated terminal.