### PR TITLE
Add var_placeholders and var_placeholders_once to the 'dap' object

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -323,12 +323,12 @@ do
     return option
   end
 
-  local var_placeholders_once = {
+  M.var_placeholders_once = {
     ['${command:pickProcess}'] = lazy.utils.pick_process,
     ['${command:pickFile}'] = lazy.utils.pick_file,
   }
 
-  local var_placeholders = {
+  M.var_placeholders = {
     ['${file}'] = function(_)
       return vim.fn.expand("%:p")
     end,
@@ -354,7 +354,7 @@ do
       return vim.fn.getcwd()
     end,
     ['${workspaceFolderBasename}'] = function(_)
-      return vim.fn.fnamemodify(vim.fn.getcwd(), ":t")
+      return vim.fn.fnamemodify(M.var_placeholders["${workspaceFolder}"], ":t")
     end,
     ['${env:([%w_]+)}'] = function(match)
       return os.getenv(match) or ''
@@ -379,10 +379,10 @@ do
       return option
     end
     local ret = option
-    for key, fn in pairs(var_placeholders) do
+    for key, fn in pairs(M.var_placeholders) do
       ret = ret:gsub(key, fn)
     end
-    for key, fn in pairs(var_placeholders_once) do
+    for key, fn in pairs(M.var_placeholders_once) do
       if ret:find(key) then
         local val = eval_option(fn)
         ret = ret:gsub(key, val)


### PR DESCRIPTION
# Description
Make available var_placeholders to the user, so that they are able to modify them if required.

Also now ${workspaceFolderBasename} dependes on ${workspaceFolder} by default.

# Use case
${workspaceFolder} can be changed to for example the git root of the project. 
