### PR TITLE
Use the correct caller fileinfo 

### DIFF
--- a/lua/dap/log.lua
+++ b/lua/dap/log.lua
@@ -86,7 +86,7 @@ function Log:_log(level, levelnr, ...)
   if argc == 0 then
     return true
   end
-  local info = debug.getinfo(2, 'Sl')
+  local info = debug.getinfo(3, 'Sl')
   local _, end_ = info.short_src:find("nvim-dap/lua", 1, true)
   local src = end_ and info.short_src:sub(end_ + 2) or info.short_src
   local fileinfo = string.format('%s:%s', src, info.currentline)


### PR DESCRIPTION
Un the current implementation, it will only log the caller function. The _log caller function is the level wrapper function,
Therefor we set the level to 3 to get  the caller(level) caller(actual caller) function info.

More info here
https://www.lua.org/pil/23.1.html
and here 
https://www.lua.org/manual/5.4/manual.html#pdf-debug.getinfo