### PR TITLE
Fix DapSetLogLevel when passing space after the level

### DIFF
--- a/plugin/dap.lua
+++ b/plugin/dap.lua
@@ -6,7 +6,7 @@ end
 local cmd = api.nvim_create_user_command
 cmd('DapSetLogLevel',
   function(opts)
-    require('dap').set_log_level(unpack(opts.fargs))
+    require('dap').set_log_level(vim.trim(opts.args))
   end,
   {
     nargs = 1,

--- a/plugin/dap.lua
+++ b/plugin/dap.lua
@@ -5,6 +5,7 @@ end
 
 local cmd = api.nvim_create_user_command
 cmd('DapSetLogLevel',
+  ---@param opts vim.api.keyset.create_user_command.command_args
   function(opts)
     require('dap').set_log_level(vim.trim(opts.args))
   end,


### PR DESCRIPTION
if you passed a space after the level it should just work you did not add any letters and its not a script.
In example if you typed:
“DapSetLogLevel DEBUG “
it will not work,
So I trimmed the function args, I also replaced `unpack(opts.fargs)` with `opts.args` because it will return the same result with less code 

Note:
`opts.fargs` is table of the function args.
`unpack(table)` convert table to string.
`opts.args` is args as string.
reference: https://neovim.io/doc/user/api.html#nvim_create_user_command()