### PR TITLE
fix: set source filetype in providers.configs

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -296,7 +296,7 @@ end
 
 
 providers.configs["dap.global"] = function(bufnr)
-  local filetype = vim.bo[bufnr].filetype
+  local filetype = vim.b["dap-srcft"] or vim.bo[bufnr].filetype
   local configurations = M.configurations[filetype] or {}
   assert(
     islist(configurations),


### PR DESCRIPTION
Addresses issue where setting dap.defaults[ft]autostart = "config" uses "dap-repl" as filetype when attempting to start config from using repl and there is no active session