### PR TITLE
Show notification for launch.json parsing errors

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -311,6 +311,10 @@ end
 
 providers.configs["dap.launch.json"] = function()
   local ok, configs = pcall(require("dap.ext.vscode").getconfigs)
+  if not ok then
+    local msg = string.format("Cannot get configurations from `launch.json`:\n%s", configs)
+    notify(msg, vim.log.levels.ERROR)
+  end
   return ok and configs or {}
 end
 

--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -312,10 +312,11 @@ end
 providers.configs["dap.launch.json"] = function()
   local ok, configs = pcall(require("dap.ext.vscode").getconfigs)
   if not ok then
-    local msg = string.format("Cannot get configurations from `launch.json`:\n%s", configs)
-    notify(msg, vim.log.levels.ERROR)
+    local msg = "Can't get configurations from launch.json:\n%s" .. configs
+    vim.notify_once(msg, vim.log.levels.WARN, {title = "DAP"})
+    return {}
   end
-  return ok and configs or {}
+  return configs
 end
 
 do


### PR DESCRIPTION
Good afternoon.

I've noticed that `nvim-dap` does not display error messages when parsing `launch.json`, so it's difficult to understand the cause of possible problems.

I suggest adding an error message, in my case it looks like this:
```
Cannot get configurations from `launch.json`:
...\Local\nvim-data\plugged\nvim-dap/lua/dap/ext/vscode.lua:150: Error parsing launch.json: Expected object key string but found T_OBJ_END at character 1180
```
