### PR TITLE
Handle nil error message for the REPL

### DIFF
--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -189,7 +189,10 @@ end
 
 local function evaluate_handler(err, resp)
   if err then
-    M.append(tostring(err), nil, { newline = false })
+    local message = tostring(err)
+    if message then
+      M.append(message, nil, { newline = false })
+    end
     return
   end
   local layer = ui.layer(repl.buf)


### PR DESCRIPTION
Hello!

This fixes a small regression introduced in https://github.com/mfussenegger/nvim-dap/commit/57669462af0753340161c166f54effff5b893ee4

Some adapters may return errors that when parsed by `utils.fmt_error` return `nil` (in spite of not being `nil` themselves), which throws an error in `M.append`.

An example is getting the value of any undefined variable with the js-debug-adapter.