### PR TITLE
Handle missing scopes

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -843,7 +843,7 @@ function Session:_request_scopes(current_frame)
     end
     local scopes = scope_resp.scopes
     current_frame.scopes = scopes
-    for _, scope in ipairs(scopes) do
+    for _, scope in ipairs(scopes or {}) do
       if not scope.expensive then
 
         ---@param resp dap.VariableResponse?


### PR DESCRIPTION
Hello!

I'm constantly running into the following error when navigating the call stack:

```
Error executing vim.schedule lua callback: ...nvim-dap/lua/dap/session.lua:846: bad argument #1 to 'ipairs' (table expected, got nil)
stack traceback:
	[C]: in function 'ipairs'
	...nvim-dap/lua/dap/session.lua:846: in function 'callback'
	...nvim-dap/lua/dap/session.lua:1093: in function <...nvim-dap/lua/dap/session.lua:1090>
```

Originally, I was navigating the call stack using `session:_frame_set(frame)`, but I can reproduce the same issue when using `require"dap".up()/down()`

According to the [spec](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Scopes), I don't think this parameter should be missing (since it's not optional), but I wonder if there's something else going on due to the navigation in the call stack?

I'm running into this issue with the vscode-js-debug specifically. What make the situation odd is that it looks like it [always returns the scopes](https://github.com/microsoft/vscode-js-debug/blob/7cd78ebf3bfcee24828bd3e39202811f53834cec/src/adapter/stackTrace.ts#L464-L547) (but I haven't delved deep into that).

I can try crafting a minimal reproduction if necessary, or getting the traces. Let me know how to best handle the situation ^^

EDIT: [related?](https://github.com/microsoft/vscode-js-debug/blob/7cd78ebf3bfcee24828bd3e39202811f53834cec/src/adapter/threads.ts#L426-L432)