### PR TITLE
Ensure response handler are called with response=nil if there is an error

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -1090,7 +1090,7 @@ function Session:handle_body(body)
     vim.schedule(function()
       local before = listeners.before[decoded.command]
       call_listener(before, self, err, response, request, decoded.request_seq)
-      callback(err, decoded.body, decoded.request_seq)
+      callback(err, response, decoded.request_seq)
       local after = listeners.after[decoded.command]
       call_listener(after, self, err, response, request, decoded.request_seq)
     end)

--- a/spec/integration_spec.lua
+++ b/spec/integration_spec.lua
@@ -24,6 +24,23 @@ describe('dap with fake server', function()
     require('dap.breakpoints').clear()
     wait(function() return dap.session() == nil end)
   end)
+
+  it("handler is called without response if there is an error", function()
+    local session = run_and_wait_until_initialized(config, server)
+    server.client.threads = function(self, request)
+      self:send_err_response(request, "this is wrong", "err1")
+    end
+
+    local err, resp
+    session:request("threads", nil, function (e, r)
+      err = e
+      resp = r
+    end)
+    wait(function() return err ~= nil end)
+    assert.is_nil(resp)
+    assert.are.same(tostring(err), "this is wrong")
+  end)
+
   it('clear breakpoints clears all active breakpoints', function()
     local session = run_and_wait_until_initialized(config, server)
     assert.are_not.same(session, nil)


### PR DESCRIPTION
Alternative to https://github.com/mfussenegger/nvim-dap/pull/1469

The `response.body` was reused as `response` despite having an error set
based on `success=false`
