### PR TITLE
Drop support for nvim-0.9.5; add support for 0.11.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        neovim_version: ['nightly', 'v0.9.5', 'v0.10.0']
+        neovim_version: ['nightly', 'v0.10.4', 'v0.11.0']
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@
 Supported Neovim versions:
 
 - Latest nightly
-- 0.10.x (Recommended)
-- 0.9.5
+- 0.11.x (Recommended)
+- 0.10.4
 
 You'll need to install and configure a debug adapter per language. See
 


### PR DESCRIPTION
For users of nvim 0.9.5 - I suggest pinning to nvim-dap to [0.10.0](https://github.com/mfussenegger/nvim-dap/releases/tag/0.10.0)
