### PR TITLE
Support arbitrary fields in dap.Configuration annotation

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -262,6 +262,7 @@ M.adapters = {}
 ---@field type string
 ---@field request "launch"|"attach"
 ---@field name string
+---@field [string] any
 
 
 --- Configurations per adapter. See `:help dap-configuration` for more help.


### PR DESCRIPTION
Hey!

When trying to use the `enrich_config` property, I noticed that adding fields to the configuration creates a lua-ls warning:

```
Fields cannot be injected into the reference of `dap.Configuration` for `foo_bar`. To do so, use `---@class` for `config`. 
```

Since configurations can hold pretty much arbitrary data (by nesting), I decided to update the annotation accordingly.