### PR TITLE
Add tabusevisible switchbuf option

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -592,11 +592,12 @@ The configuration values are set via `dap.defaults.fallback` (for global) or
                        See |'switchbuf'|. Defaults to the global `'switchbuf'`
                        setting.
 
-                       nvim-dap provides an additional `usevisible` option
-                       that can be used to prevent jumps within the active
-                       window if a stopped event is within the visible region.
-                       Best used in combination with other options. For
-                       example: 'usevisible,usetab,uselast'
+                       nvim-dap provides an additional `usevisible`
+                       (`tabusevisible`) option that can be used to prevent
+                       jumps within the active window (tab) if a stopped event
+                       is within the visible region. Best used in combination
+                       with other options. For example:
+                       'usevisible,usetab,uselast'
 
 - `on_output`. A function with two parameters: `session` and `output_event`:
   Overrides the default output handling with a custom handler.

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -444,6 +444,7 @@ local function jump_to_location(bufnr, line, column, switchbuf, filetype)
   end
 
   local cur_win = api.nvim_get_current_win()
+  local cur_tab = api.nvim_win_get_tabpage(cur_win)
   local switchbuf_fn = {}
 
   function switchbuf_fn.uselast()
@@ -468,6 +469,19 @@ local function jump_to_location(bufnr, line, column, switchbuf, filetype)
       local last = vim.fn.line("w$", cur_win)
       if first <= line and line <= last then
         return true
+      end
+    end
+    return false
+  end
+
+  function switchbuf_fn.tabusevisible()
+    for _, win in ipairs(vim.api.nvim_tabpage_list_wins(cur_tab)) do
+      if api.nvim_win_get_buf(win) == bufnr then
+        local first = vim.fn.line("w0", win)
+        local last = vim.fn.line("w$", win)
+        if first <= line and line <= last then
+          return true
+        end
       end
     end
     return false


### PR DESCRIPTION
Addresses #1470 

I've been using this for a couple of weeks without any issues. But I've been holding back onto opening the PR because I don't think that's a long-term solution: adding variations to the `switchbuf` option is awkward. 

You'd think that this would be the last one, but we can go further. For instance, the `usetab` value does not take into account if there's a window where the line is visible (akin to the `usevisible` option) within the same tab. Instead, with `usetab`, the first window that matches the buffer is always used, regardless of the line being visible elsewhere. 

Thoughts?