### PR TITLE
replace nvim_open_term with vim.jn.jobstart(..., {term = true})

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -265,14 +265,15 @@ local function run_in_terminal(lsession, request)
 
   local jobid
   vim.api.nvim_buf_call(terminal_buf, function()
-    jobid = vim.fn.jobstart(body.args, {
+    local termopen = vim.fn.has("nvim-0.11") == 1 and vim.fn.jobstart or vim.fn.termopen
+    jobid = termopen(body.args, {
       env = next(body.env or {}) and body.env or vim.empty_dict(),
       cwd = (body.cwd and body.cwd ~= '') and body.cwd or nil,
       height = terminal_win and api.nvim_win_get_height(terminal_win) or math.ceil(vim.o.lines / 2),
       width = terminal_win and api.nvim_win_get_width(terminal_win) or vim.o.columns,
-      term = true,
+      term = vim.fn.has("nvim-0.11") == 1 and true or nil,
       on_exit = function()
-         terminals.release(terminal_buf)
+        terminals.release(terminal_buf)
       end
     })
   end)


### PR DESCRIPTION
This PR is a continuation of #1488, where I explored some nvim-dap terminal issues—specifically, wrong scrollback handling and the cursor not changing its shape when debugging Neovim. Resizing problems, as I found out, were due to the debug adapter, so this PR doesn’t fix those.

While continuing to use it, I faced other issues with this terminal. I launched tests in my project, and for some reason, the test output didn’t have colors. With this patch, all three issues I found disappeared. It also remove the fragile nvim_chan_send logic and lets neovim handle it itself, which I think is always for the best. The 'Process exited' and 'CR' used to delete the buffer at the end are also removed because neovim :terminal already handles them

So this patch makes the nvim-dap-provided terminal behave exactly like the terminal you get using :terminal cmd, without the strange quirks we get when creating a terminal using nvim_open_term.

I also saw your comments about using termopen before and its problems, but with this implementation, it doesn’t have such drawbacks (if I understand those issues correctly):
https://github.com/mfussenegger/nvim-dap/issues/1488#issuecomment-2807530368

In the video, I show the third issue I found with the terminal created by nvim_open_term. First, I show how it works now: the output doesn’t have colors (in this case, for some reason). Then I apply this patch and show how it works after this PR. Now you can see everything works as expected. The output has colors.

https://github.com/user-attachments/assets/5873c297-2929-44c8-bf5c-eedccc592cd7

If this is still not convincing enough, I can provide additional videos showcasing issues with scrollback.

