### PR TITLE
REPL commands for stepping with instruction granularity

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -973,7 +973,9 @@ repl.open({winopts}, {wincmd})                                 *dap.repl.open()*
           .exit               Closes the REPL
           .c or .continue     Same as |dap.continue|
           .n or .next         Same as |dap.step_over|
+          .ni or .nexti       Same as |dap.step_over| with instruction granularity
           .into               Same as |dap.step_into|
+          .intoi              Same as |dap.step_into| with instruction granularity
           .into_target        Same as |dap.step_into{askForTargets=true}|
           .out                Same as |dap.step_out|
           .up                 Same as |dap.up|
@@ -984,6 +986,7 @@ repl.open({winopts}, {wincmd})                                 *dap.repl.open()*
           .frames             Print the stack frames
           .capabilities       Print the capabilities of the debug adapter
           .b or .back         Same as |dap.step_back|
+          .bi or .backi       Same as |dap.step_back| with instruction granularity
           .rc or
           .reverse-continue   Same as |dap.reverse_continue|
 

--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -876,9 +876,9 @@ step_into([{opts}])                                            *dap.step_into()*
         want to step into if there are multiple choices.
 
         Some debug adapters allow a more fine-grained control over the
-        behavior of this command using the `steppingGranularity` {opts} parameter:
+        behavior of this command using the `granularity` {opts} parameter:
 
-        steppingGranularity:
+        granularity:
           Can be 'statement' | 'line' | 'instruction'
           Will fall back to dap.defaults.fallback.stepping_granularity
           Default: 'statement'

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -123,9 +123,12 @@ local repl = ui.new_view(
 M.commands = {
   continue = {'.continue', '.c'},
   next_ = {'.next', '.n'},
+  nexti = {'.nexti', '.ni'},
   step_back = {'.back', '.b'},
+  step_backi = {'.backi', '.bi'},
   reverse_continue = {'.reverse-continue', '.rc'},
   into = {'.into'},
+  intoi = {'.intoi'},
   into_targets = {'.into-targets'},
   out = {'.out'},
   scopes = {'.scopes'},
@@ -290,10 +293,14 @@ local function coexecute(text, opts)
     require('dap').continue()
   elseif vim.tbl_contains(M.commands.next_, text) then
     require('dap').step_over()
+  elseif vim.tbl_contains(M.commands.nexti, text) then
+    require('dap').step_over({granularity = "instruction"})
   elseif vim.tbl_contains(M.commands.capabilities, text) then
     M.append(vim.inspect(session.capabilities))
   elseif vim.tbl_contains(M.commands.into, text) then
     require('dap').step_into()
+  elseif vim.tbl_contains(M.commands.intoi, text) then
+    require('dap').step_into({granularity = "instruction"})
   elseif vim.tbl_contains(M.commands.into_targets, text) then
     require('dap').step_into({askForTargets=true})
   elseif vim.tbl_contains(M.commands.out, text) then
@@ -303,6 +310,8 @@ local function coexecute(text, opts)
     M.print_stackframes()
   elseif vim.tbl_contains(M.commands.step_back, text) then
     require('dap').step_back()
+  elseif vim.tbl_contains(M.commands.step_backi, text) then
+    require('dap').step_back({granularity = "instruction"})
   elseif vim.tbl_contains(M.commands.pause, text) then
     session:_pause()
   elseif vim.tbl_contains(M.commands.reverse_continue, text) then


### PR DESCRIPTION
Hi!

As in the title, this PR adds REPL commands for stepping with instruction granularity regardless of what is set as the default stepping granularity.

It also fixes name of `granularity` parameter in docs.