### PR TITLE
Call handlers on session change and ability to disable terminal buffer pooling

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -138,7 +138,9 @@ M.listeners = {
   }),
 
   ---@type table<string, fun(config: dap.Configuration):dap.Configuration>
-  on_config = {}
+  on_config = {},
+  ---@type table<string, fun(session: dap.Session|nil)>
+  on_session_change = {},
 }
 
 
@@ -549,17 +551,14 @@ local function select_config_and_run(opts)
   end)
 end
 
-local on_session_changed_handlers = {}
-
-M.register_on_session_changed_handler = function(f)
-  table.insert(on_session_changed_handlers, f)
-end
 
 ---@param new_session dap.Session|nil
 local set_session = function(new_session)
   session = new_session
-  for _, handler in ipairs(on_session_changed_handlers) do
-    handler(session)
+
+  local listeners = M.listeners["on_session_change"]
+  for key, listener in pairs(listeners) do
+    listener(new_session)
   end
 end
 

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -279,7 +279,9 @@ local function run_in_terminal(lsession, request)
       height = terminal_win and api.nvim_win_get_height(terminal_win) or math.ceil(vim.o.lines / 2),
       width = terminal_win and api.nvim_win_get_width(terminal_win) or vim.o.columns,
       term = vim.fn.has("nvim-0.11") == 1 and true or nil,
-      on_exit = function() terminals.release(terminal_buf) end,
+      on_exit = function()
+        terminals.release(terminal_buf)
+      end,
     })
   end)
 

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -230,7 +230,9 @@ do
 
   ---@param b number
   function terminals.release(b)
-    pool[b] = true
+    if enable_termbuf_pooling then
+      pool[b] = true
+    end
   end
 end
 
@@ -269,7 +271,6 @@ local function run_in_terminal(lsession, request)
   end
 
   local jobid
-  local on_exit = enable_termbuf_pooling and function() terminals.release(terminal_buf) end or nil
   vim.api.nvim_buf_call(terminal_buf, function()
     local termopen = vim.fn.has("nvim-0.11") == 1 and vim.fn.jobstart or vim.fn.termopen
     jobid = termopen(body.args, {
@@ -278,7 +279,7 @@ local function run_in_terminal(lsession, request)
       height = terminal_win and api.nvim_win_get_height(terminal_win) or math.ceil(vim.o.lines / 2),
       width = terminal_win and api.nvim_win_get_width(terminal_win) or vim.o.columns,
       term = vim.fn.has("nvim-0.11") == 1 and true or nil,
-      on_exit = on_exit,
+      on_exit = function() terminals.release(terminal_buf) end,
     })
   end)
 


### PR DESCRIPTION
Hi there!

Me and @igorlfs are working on a [PR to nvim-dap-view](https://github.com/igorlfs/nvim-dap-view/pull/51) which will enable multi-session support.

There are two problems that prevent us from implementing this feature fully, namely:
1. It's not possible for `nvim-dap-view` to know when the dap session changes (so we can't show the active sessions terminal buffer when it changes).
2. `nvim-dap` will pool terminal buffers, which makes it hard/impossible for us to know which one is being used for which session.

I've tried to implement some minimal changes that fixes these issues for us:
1. Instead of opaquely setting the `session` in various places, call [`set_session`](https://github.com/Run1e/nvim-dap/commit/87ad93697c16d208630bf5ca0d8d5ea29ad4fb40#diff-b59b772740a7d213d40288d3c87a48040714405a93860817efa817d8cc2e2a94R558-R564) which also calls a list of handlers that other plugins can register using [`register_on_session_changed_handler`](https://github.com/Run1e/nvim-dap/commit/87ad93697c16d208630bf5ca0d8d5ea29ad4fb40#diff-b59b772740a7d213d40288d3c87a48040714405a93860817efa817d8cc2e2a94R552-R556).
2. Implement two functions that can be used to [enable or disable](https://github.com/Run1e/nvim-dap/commit/87ad93697c16d208630bf5ca0d8d5ea29ad4fb40#diff-1c238a5ffb6d36f9412528c8783aacf498b7c4456f7ce2131779e1ea04bb98b2R174-R182) the terminal buffer pooling.

Disabling the terminal buffer pooling has the effect that each new session will *always* call the `terminal_win_cmd` function which in practice means plugins like `nvim-dap-view` can gain control over how terminal buffers are created and used for sessions if they need to.