### PR TITLE
Extract the logic of awaiting a bunch of async function results into a separate function, await_all. fix #1491

### DIFF
--- a/lua/dap/async.lua
+++ b/lua/dap/async.lua
@@ -1,9 +1,9 @@
-local M = {}
+local async = {}
 
 --- Run a function in a coroutine with error handling via vim.notify
 ---
 --- If run is called within a coroutine, no new coroutine is created.
-function M.run(fn)
+function async.run(fn)
   local co, is_main = coroutine.running()
   if co and not is_main then
     fn()
@@ -17,4 +17,39 @@ function M.run(fn)
   end
 end
 
-return M
+async.countdown = {}
+---Invokes cb immediately if count == 0
+---@param count integer
+---@param cb fun()
+function async.countdown.new(count, cb)
+  assert(count >= 0, "Countdown counter should be >= 0")
+  local called = false
+  if count == 0 then
+    called = true
+    cb()
+  end
+  return function()
+    count = count - 1
+    if count == 0 and not called then
+      cb()
+      called = true
+    end
+  end
+end
+
+---Function that represents some deferred computation
+---When called, accepts an `on_done` argument. on_done must be called
+---when the computation is completed
+---@alias dap.async.Thunk fun(on_done: fun())
+
+---Await all thunks. Invoke on_done when all thunks are finished
+---@param thunks dap.async.Thunk[]
+---@param on_done fun()
+function async.await_all(thunks, on_done)
+  local countdown = async.countdown.new(#thunks, on_done)
+  for _, thunk in ipairs(thunks) do
+    thunk(countdown)
+  end
+end
+
+return async


### PR DESCRIPTION
1. Extract the logic of awaiting a bunch of async function results into a separate util function, await_all.

2. Fixes the bug that caused the scopes widget to turn blank when trying to expand an empty collection. That was happening because the callback wasn’t called if the unloaded (#variables) was equal to 0.
From my tests, it also fixes the issue #1491.