### PR TITLE
Fix first line in doc for local-additions

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -1,4 +1,4 @@
-DAP client                                           *dap.txt*
+*dap.txt*                                         DAP client
 
 
 nvim-dap is a Debug Adapter Protocol client, or "debugger", or "debug-frontend".


### PR DESCRIPTION
The documentation for vim help pages states that a first line is required for the file to appear under :help local-additions, with the following format: *tag* description

This change modifies the first line to follow that format