### PR TITLE
feat(widgets): add 'q' mapping to close centered float widget for convenience

### DIFF
--- a/lua/dap/ui/widgets.lua
+++ b/lua/dap/ui/widgets.lua
@@ -65,6 +65,7 @@ function M.new_centered_float_win(buf)
     vim.wo[win].wrap = false
   end
   vim.bo[buf].filetype = "dap-float"
+  vim.keymap.set('n', 'q', '<cmd>close<cr>', { buffer = buf, nowait = true, silent = true })
   return win
 end
 


### PR DESCRIPTION
This PR adds buffer-local 'q' mapping in `new_centered_float_win(buf)`  widget to close floating windows.

**Motivation:**
Users currently need to type `:q<CR>` to close the dap floating window, which is less convenient than the standard `q` key.
