### PR TITLE
Retrieve `term_buf` by session

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -56,6 +56,7 @@ end
 ---@field private handle uv.uv_stream_t
 ---@field current_frame dap.StackFrame|nil
 ---@field initialized boolean
+---@field term_buf? integer
 ---@field stopped_thread_id number|nil
 ---@field id number
 ---@field threads table<number, dap.Thread>
@@ -258,6 +259,7 @@ local function run_in_terminal(lsession, request)
   end
 
   local jobid
+  lsession.term_buf = terminal_buf
   vim.api.nvim_buf_call(terminal_buf, function()
     local termopen = vim.fn.has("nvim-0.11") == 1 and vim.fn.jobstart or vim.fn.termopen
     jobid = termopen(body.args, {


### PR DESCRIPTION
Implements https://github.com/mfussenegger/nvim-dap/discussions/1523#discussioncomment-14215672

Alternative to #1519 

**Problem**: UI plugins need to accurately retrieve the terminal buffer for the current session, so they can show the corresponding buf.

**Solution**: add an optional field to `dap.Session` that stores the buffer.

By the way, I'm planning on making some more contributions, would you prefer if new PRs were opened on codeberg?