### PR TITLE
Set cursor outside custom switchbuf function

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -598,8 +598,9 @@ The configuration values are set via `dap.defaults.fallback` (for global) or
   example: 'usevisible,usetab,uselast'
 
   For more complex use cases, nvim-dap allows overriding with a function. The
-  function receives 3 arguments: (bufnr, line, column). It has full control of
-  how Neovim should behave and it is not expected to return anything.
+  function receives bufnr and should return a window id with its current
+  buffer set to the given buffer. It has full control of how Neovim should
+  behave.
 
 
 - `on_output`. A function with two parameters: `session` and `output_event`:

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -409,7 +409,7 @@ end
 ---@param bufnr number
 ---@param line number
 ---@param column number
----@param switchbuf string|fun(bufnr: integer, line: integer, column: integer):nil
+---@param switchbuf string|fun(bufnr: integer):integer
 ---@param filetype string
 local function jump_to_location(bufnr, line, column, switchbuf, filetype)
   progress.report('Stopped at line ' .. line)
@@ -517,7 +517,8 @@ local function jump_to_location(bufnr, line, column, switchbuf, filetype)
   end
 
   if type(switchbuf) == "function" then
-    switchbuf(bufnr, line, column)
+    local win = switchbuf(bufnr)
+    set_cursor(win, line, column)
     return
   end
 


### PR DESCRIPTION
Setting the cursor is common to any switchbuf function and should handle error. So nvim-dap should set the cursor on behalf of users.