### PR TITLE
fall back to `step_into` if `askForTargets` is specified but no targets are available

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -726,6 +726,12 @@ function M.step_into(opts)
       return
     end
 
+    -- Fall back to step-into/over functionality if there are no targets
+    if #response.targets == 0 then
+      M.step_into(opts)
+      return
+    end
+
     lazy.ui.pick_if_many(
       response.targets,
       "Step into which function?",


### PR DESCRIPTION
fixes #1561