### PR TITLE
feature: allow cwd for external terminal

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -661,28 +661,6 @@ should be launched by nvim-dap:
   }
 <
 
-You can include the placeholder `${cwd}` in `external_terminal.args` to pass
-the working directory requested by the debug adapter (for example from
-`launch.json`). This is useful for terminals that require an explicit working
-directory flag.
-
-Examples:
-
->lua
-  local dap = require('dap')
-  -- Kitty: open in the requested cwd and run the command, keep the tab open
-  dap.defaults.fallback.external_terminal = {
-    command = 'kitty';
-    args = { '--hold', '-d', '${cwd}' };
-  }
-
-  -- alacritty: set working directory explicitly
-  dap.defaults.fallback.external_terminal = {
-    command = 'alacritty';
-    args = { '--working-directory', '${cwd}', '-e' };
-  }
-<
-
 Some debug adapters support launching the debugee in a terminal, but don't
 provide an option to choose between integrated terminal or external terminal.
 `nvim-dap` provides an option to force the external terminal.

--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -125,18 +125,7 @@ local function launch_external_terminal(env, terminal, args, cwd)
   local handle
   local pid_or_err
   local full_args = {}
-  -- Allow passing the desired cwd to terminals via placeholder substitution.
-  -- Users can add "${cwd}" to their external_terminal.args (e.g. kitty: {"--hold", "-d", "${cwd}"})
-  local function substitute(arg)
-    if type(arg) == "string" and cwd and cwd ~= '' then
-      return (arg:gsub("%${cwd}", cwd))
-    end
-    return arg
-  end
-  for _, a in ipairs(terminal.args or {}) do
-    full_args[#full_args+1] = substitute(a)
-  end
-  -- Adapter-provided args are appended as-is
+  vim.list_extend(full_args, terminal.args or {})
   vim.list_extend(full_args, args)
   -- Initializing to nil is important so environment is inherited by the terminal
   local env_formatted = nil
@@ -315,7 +304,6 @@ local function run_in_terminal(lsession, request)
       };
     })
   end
-
 end
 
 


### PR DESCRIPTION
This change allows users to pass the working directory (cwd) from the debug adapter to the external terminal.

Some terminal emulators require an explicit flag to set the working directory. This was not previously possible, as the cwd from the debug adapter was not passed to the external terminal command.

This PR introduces a ${cwd} placeholder that can be used in the external_terminal.args configuration. nvim-dap will substitute this placeholder with the cwd provided by the debug adapter in the runInTerminal request.
