### PR TITLE
[feature] Added silent parameter to the dap.repl.execute function to not repeat the command after execution.

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -173,6 +173,9 @@ M.defaults = setmetatable(
 
       ---@type nil|fun(session: dap.Session, output: dap.OutputEvent)
       on_output = nil,
+
+      ---@type table<string, boolean> File types where REPL should not show tree structure/metadata
+      repl_hide_tree_filetypes = {},
     },
   },
   {

--- a/lua/dap/repl.lua
+++ b/lua/dap/repl.lua
@@ -205,24 +205,31 @@ local function evaluate_handler(err, resp)
     M.append(tostring(err), nil, { newline = true })
     return
   end
-  local layer = ui.layer(repl.buf)
-  local attributes = (resp.presentationHint or {}).attributes or {}
-  if resp.variablesReference > 0 or vim.tbl_contains(attributes, 'rawString') then
-    local spec = require('dap.entity').variable.tree_spec
-    local tree = ui.new_tree(spec)
-    -- tree.render would "append" twice, once for the top element and once for the children
-    -- Appending twice would result in a intermediate "dap> " prompt
-    -- To avoid that this eagerly fetches the children; pre-renders the region
-    -- and lets tree.render override it
-    if spec.has_children(resp) then
-      spec.fetch_children(resp, function()
-        tree.render(layer, resp, nil)
-      end)
-    else
-      tree.render(layer, resp, nil)
-    end
+  local srcft = vim.b[repl.buf]["dap-srcft"] or ""
+  local hide_tree_filetypes = require("dap").defaults.fallback.repl_hide_tree_filetypes or {}
+  local shoudl_hide_tree = hide_tree_filetypes[srcft] or false
+  if shoudl_hide_tree then
+    M.append(resp.result, nil, { newline = true})
   else
-    M.append(resp.result, nil, { newline = true })
+    local layer = ui.layer(repl.buf)
+    local attributes = (resp.presentationHint or {}).attributes or {}
+    if resp.variablesReference > 0 or vim.tbl_contains(attributes, 'rawString') then
+      local spec = require('dap.entity').variable.tree_spec
+      local tree = ui.new_tree(spec)
+      -- tree.render would "append" twice, once for the top element and once for the children
+      -- Appending twice would result in a intermediate "dap> " prompt
+      -- To avoid that this eagerly fetches the children; pre-renders the region
+      -- and lets tree.render override it
+      if spec.has_children(resp) then
+        spec.fetch_children(resp, function()
+          tree.render(layer, resp, nil)
+        end)
+      else
+        tree.render(layer, resp, nil)
+      end
+    else
+      M.append(resp.result, nil, { newline = true })
+    end
   end
 end
 


### PR DESCRIPTION
**Example for Python**
```lua
local repl = require('dap.repl')

repl.commands = vim.tbl_extend('force', repl.commands, {
    custom_commands = {
        ["."] = function(expr)
            if not expr or expr:match("^%s*$") then
                repl.append('Usage: . <expression>')
                return
            end

            local wrapped = 'repr(' .. expr .. ')'
            repl.execute(wrapped, {context='repl', silent=true})
        end,
    }
})
```

Execution in the repl:

```
. <variable>
```
to show a variable without meta information.

I have tested this in python for the nvim-dap commit 6782b09.

This is related to these issues:
- https://github.com/mfussenegger/nvim-dap/issues/737
- https://github.com/mfussenegger/nvim-dap/issues/1062