### PR TITLE
fix: wrap restart config in arguments field per DAP spec

### DIFF
--- a/lua/dap.lua
+++ b/lua/dap.lua
@@ -949,7 +949,7 @@ function M.restart(config, opts)
   if lsession.capabilities.supportsRestartRequest then
     lazy.async.run(function()
       config = prepare_config(config)
-      lsession:request('restart', config, function(err0, _)
+      lsession:request('restart', { arguments = config }, function(err0, _)
         if err0 then
           notify('Error restarting debug adapter: ' .. tostring(err0), vim.log.levels.ERROR)
         else


### PR DESCRIPTION
## Problem

The `restart` request sends the configuration directly as the request body, but according to the [DAP specification](https://microsoft.github.io/debug-adapter-protocol/specification), it should be wrapped in an `arguments` field:

```typescript
interface RestartArguments {
  /**
   * The latest version of the `launch` or `attach` configuration.
   */
  arguments?: LaunchRequestArguments | AttachRequestArguments;
}
```

This causes issues with debug adapters like Delve (Go debugger) that expect the spec-compliant format. When restarting a debug session, the restart request completes successfully but the debuggee doesn't actually restart.

## Solution

Wrap the config in `{ arguments = config }` when sending the restart request, matching the DAP specification.

## References

- Issue: #1575
- DAP specification: https://microsoft.github.io/debug-adapter-protocol/specification (search for `RestartArguments`)
- Delve restart issue: https://github.com/go-delve/delve/issues/4102
