### PR TITLE
send empty array for setbreakpoints command

### DIFF
--- a/lua/dap/session.lua
+++ b/lua/dap/session.lua
@@ -953,10 +953,8 @@ do
   function Session:set_breakpoints(bps, on_done)
     local num_requests = vim.tbl_count(bps)
     if num_requests == 0 then
-      if on_done then
-        on_done()
-      end
-      return
+	  local bufnr = vim.api.nvim_get_current_buf()
+      bps = { [bufnr] = {} }
     end
     for bufnr, buf_bps in pairs(bps) do
       notify_if_missing_capability(buf_bps, self.capabilities)


### PR DESCRIPTION
1. Problem

Some debugger like matlab-lsp, It removes unused breakpoints when lsp received setbreakpoints command.

Previously, set_breakpoints() function send nothing when there are no breakpoint. It makes that lsp cannot remove remained breakpoints which are set before.

2. Solution

Send setbreakpoints request with empty array even though there is no breakpoints